### PR TITLE
Make `Graphviz` optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,23 @@ CI/CD-style justification framework.
 jPipe Runner requires:
 
 - Python (version 3.12 or later)
+
+Optional dependency:
+
 - [Graphviz](https://www.graphviz.org/) (version 2.46 or later)
 - C/C++ Compiler
 
 > [!NOTE]
-> These instructions assume you have Python, Graphviz and a C/C++ Compiler on your computer.
+> Graphviz is required and used for debugging purposes only.
+
+To install `graphviz` on Debian/Ubuntu:
+
+```shell
+$ sudo apt-get install \
+    --no-install-recommends \
+    --no-install-suggests -y \
+    graphviz graphviz-dev
+ ```
 
 ### Pip
 

--- a/action.yml
+++ b/action.yml
@@ -33,15 +33,9 @@ runs:
       with:
         python-version: "3.13"
 
-    - name: Install dependencies
+    - name: Install jpipe-runner
       shell: bash
-      env:
-        DEBIAN_FRONTEND: "noninteractive"
       run: |
-        sudo apt-get install \
-          --no-install-recommends \
-          --no-install-suggests -y \
-          graphviz graphviz-dev
         pip install -U 'git+https://github.com/ace-design/jpipe-runner.git@${{ inputs.version }}'
 
     - name: Run jpipe-runner

--- a/jpipe_runner/jpipe.py
+++ b/jpipe_runner/jpipe.py
@@ -14,7 +14,6 @@ from typing import (Any,
                     Iterator)
 
 import networkx as nx
-from networkx.drawing.nx_agraph import to_agraph
 
 from jpipe_runner.enums import (ClassType,
                                 VariableType,
@@ -164,6 +163,11 @@ class Justification(nx.DiGraph):
                         path: Optional[Any] = None,
                         format: Optional[str] = None,
                         ) -> bytes | None:
+        try:
+            from networkx.drawing.nx_agraph import to_agraph
+        except ImportError as e:
+            raise ImportError("pygraphviz is required to enable this feature") from e
+
         agraph = to_agraph(self)
 
         agraph.graph_attr.update(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 lark==1.2.2
 networkx==3.4.2
-pygraphviz==1.14
 termcolor==2.5.0


### PR DESCRIPTION
Graphviz is required and used for debugging purposes only.