### PR TITLE
Refactor to use pure-Python graphviz and fix PPA build dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,7 @@ jobs:
         if: steps.cache-apt.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            graphviz \
-            libgraphviz-dev \
-            pkg-config \
-            python3-dev
+          sudo apt-get install -y graphviz
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,12 +86,7 @@ jobs:
         if: steps.cache-apt.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            graphviz \
-            libgraphviz-dev \
-            pkg-config \
-            python3-dev
+          sudo apt-get install -y graphviz
 
       - name: Install dependencies
         run: |
@@ -144,12 +139,7 @@ jobs:
         if: steps.cache-apt.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            graphviz \
-            libgraphviz-dev \
-            pkg-config \
-            python3-dev
+          sudo apt-get install -y graphviz
 
       - name: Install dependencies
         run: |
@@ -211,12 +201,7 @@ jobs:
         if: steps.cache-apt.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            graphviz \
-            libgraphviz-dev \
-            pkg-config \
-            python3-dev
+          sudo apt-get install -y graphviz
 
       - name: Install dependencies
         run: |
@@ -275,12 +260,7 @@ jobs:
         if: steps.cache-apt.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            graphviz \
-            libgraphviz-dev \
-            pkg-config \
-            python3-dev
+          sudo apt-get install -y graphviz
 
       - name: Install dependencies
         run: |
@@ -409,12 +389,7 @@ jobs:
         if: steps.cache-apt.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            graphviz \
-            libgraphviz-dev \
-            pkg-config \
-            python3-dev
+          sudo apt-get install -y graphviz
 
       - name: Install dependencies
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,15 +105,7 @@ Triggered by pushing a `v*.*.*` tag whose version matches `pyproject.toml`. The 
   ```
   Homebrew's Poetry leaks system packages (e.g. `tbb`) into its resolver, breaking plugin installs.
 
-- **Graphviz system dependency**: pygraphviz compiles a C extension — Graphviz headers must be on the compiler path. On macOS with Homebrew:
-  ```bash
-  brew install graphviz
-  export CFLAGS="-I$(brew --prefix graphviz)/include"
-  export LDFLAGS="-L$(brew --prefix graphviz)/lib"
-  poetry install
-  ```
-  Add the two `export` lines to `~/.zshrc` to avoid setting them every session.
-  On Linux: `sudo apt-get install graphviz libgraphviz-dev pkg-config build-essential python3-dev`.
+- **Graphviz system dependency**: the `graphviz` Python package calls the `dot` binary at runtime — only the Graphviz binary is needed, no C headers. On macOS: `brew install graphviz`. On Linux: `sudo apt-get install graphviz`.
 
 - The `setup.py` is only needed for Debian packaging (stdeb); Poetry handles everything else.
 - Python version is pinned to `>=3.11` in `pyproject.toml` but CI only tests 3.11 — consider matrix testing.

--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y graphviz libgraphviz-dev pkg-config
+        sudo apt-get install -y graphviz
 
     - name: Set up Python
       if: ${{ !inputs.python_path }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -291,6 +291,23 @@ files = [
 ]
 
 [[package]]
+name = "graphviz"
+version = "0.21"
+description = "Simple Python interface for Graphviz"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "graphviz-0.21-py3-none-any.whl", hash = "sha256:54f33de9f4f911d7e84e4191749cac8cc5653f815b06738c54db9a15ab8b1e42"},
+    {file = "graphviz-0.21.tar.gz", hash = "sha256:20743e7183be82aaaa8ad6c93f8893c923bd6658a04c32ee115edb3c8a835f78"},
+]
+
+[package.extras]
+dev = ["Flake8-pyproject", "build", "flake8", "pep8-naming", "tox (>=3)", "twine", "wheel"]
+docs = ["sphinx (>=5,<7)", "sphinx-autodoc-typehints", "sphinx-rtd-theme (>=0.2.5)"]
+test = ["coverage", "pytest (>=7,<8.1)", "pytest-cov", "pytest-mock (>=3)"]
+
+[[package]]
 name = "idna"
 version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -487,17 +504,6 @@ markers = {main = "extra == \"docs\" or extra == \"full\""}
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
-
-[[package]]
-name = "pygraphviz"
-version = "1.14"
-description = "Python interface to Graphviz"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "pygraphviz-1.14.tar.gz", hash = "sha256:c10df02377f4e39b00ae17c862f4ee7e5767317f1c6b2dfd04cea6acc7fc2bea"},
-]
 
 [[package]]
 name = "pytest"
@@ -854,4 +860,4 @@ full = ["sphinx"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "112376ed305bd60da9cd7ae51271950e2bcd3bcc6819536af8868bea21e7f6c9"
+content-hash = "f58597c904be92139cb7436812c82edf24dae80dc2e79b477331322e90fcc128"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jpipe-runner"
-version = "3.2.0"
+version = "3.3.0"
 description = "A Justification Runner designed for jPipe."
 authors = [
     "Jason Lyu <xjasonlyu@gmail.com>",
@@ -22,7 +22,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.11"
 networkx = "3.5"
-pygraphviz = "1.14"
+graphviz = ">=0.20"
 pyyaml = "6.0.2"
 
 sphinx = { version = "8.1.3", optional = true }

--- a/script/build-deb.sh
+++ b/script/build-deb.sh
@@ -62,9 +62,9 @@ echo "13" > debian/compat
 
 CONTROL_FILE="debian/control"
 if grep -q '^Build-Depends:' "$CONTROL_FILE"; then
-  sed -i 's/^Build-Depends:.*/Build-Depends: debhelper (>= 10), dh-python, python3-all, python3-setuptools/' "$CONTROL_FILE"
+  sed -i 's/^Build-Depends:.*/Build-Depends: debhelper (>= 10), dh-python, python3-all, python3-setuptools, python3-tomli/' "$CONTROL_FILE"
 else
-  sed -i '1aBuild-Depends: debhelper (>= 10), dh-python, python3-all, python3-setuptools' "$CONTROL_FILE"
+  sed -i '1aBuild-Depends: debhelper (>= 10), dh-python, python3-all, python3-setuptools, python3-tomli' "$CONTROL_FILE"
 fi
 
 # Rename binary package if needed

--- a/src/jpipe_runner/framework/engine.py
+++ b/src/jpipe_runner/framework/engine.py
@@ -592,21 +592,18 @@ class PipelineEngine:
         :param filename: Output filename (without extension).
         :param format: Image format string (e.g. "png", "svg", "pdf").
         """
-        try:
-            from networkx.drawing.nx_agraph import to_agraph
-        except ImportError as e:
-            raise ImportError("pygraphviz is required to enable this feature") from e
+        import graphviz as gv
 
         resolved_path = self._resolve_output_path(output_path, filename)
 
         G = self.graph.copy()
-        A = to_agraph(G)
-        A.graph_attr.update(rankdir="BT")
+        dot = gv.Digraph()
+        dot.attr(rankdir="BT")
 
-        self._style_nodes(A, G, status_dict)
-        self._style_edges(A, G, status_dict)
+        self._style_nodes(dot, G, status_dict)
+        self._style_edges(dot, G, status_dict)
 
-        A.draw(resolved_path.with_suffix(f".{format}"), format=format, prog="dot")
+        dot.render(str(resolved_path), format=format, engine="dot", cleanup=True)
 
     @staticmethod
     def _resolve_output_path(output_path: str, filename: str) -> Path:
@@ -623,63 +620,54 @@ class PipelineEngine:
         return path / filename
 
     @staticmethod
-    def _style_nodes(A: Any, G: nx.DiGraph, status_dict: dict[str, str]) -> None:
+    def _style_nodes(dot: Any, G: nx.DiGraph, status_dict: dict[str, str]) -> None:
         """
         Apply visual styles to graph nodes based on their type and execution status.
 
-        :param A: AGraph (pygraphviz) instance to style.
+        :param dot: graphviz.Digraph instance to add nodes to.
         :param G: NetworkX DiGraph with node attribute data.
         :param status_dict: Mapping of node id -> status string ("PASS", "FAIL", "SKIP").
         """
         node_attr_map = {
-            "conclusion": dict(fillcolor="lightgrey", shape="rect", style="filled"),
-            "strategy": dict(fillcolor="palegreen", shape="parallelogram", style="filled"),
-            "sub-conclusion": dict(color="dodgerblue", shape="rect"),
-            "evidence": dict(fillcolor="lightskyblue2", shape="rect", style="filled"),
-            "support": dict(fillcolor="lightcoral", shape="rect", style="filled"),
+            "conclusion":     {"shape": "rect",    "style": "filled,rounded", "fillcolor": "lightgrey"},
+            "sub-conclusion": {"shape": "rect",    "color": "#0072B2"},
+            "strategy":       {"shape": "hexagon", "style": "filled",         "fillcolor": "#F0C27F"},
+            "evidence":       {"shape": "note",    "style": "filled",         "fillcolor": "#9ECAE1"},
+            "support":        {"shape": "rect",    "style": "dotted"},
         }
         for node_id, attrs in G.nodes(data=True):
             var_type = attrs.get("type", "").lower()
-            style = node_attr_map.get(
+            style = dict(node_attr_map.get(
                 var_type, dict(fillcolor="white", shape="ellipse", style="filled")
-            )
-            n = A.get_node(node_id)
-            for k, v in style.items():
-                n.attr[k] = v
+            ))
 
             status = status_dict.get(node_id, "UNKNOWN")
             logging.info("Setting node color for %s with status %s", node_id, status)
             if status == StatusType.FAIL.name:
-                n.attr["style"] = "filled"
-                n.attr["fillcolor"] = "red"
-                n.attr["fontcolor"] = "white"
-                n.attr["fontname"] = "Helvetica-Bold"
+                style.update(style="filled", fillcolor="red", fontcolor="white", fontname="Helvetica-Bold")
             elif status == StatusType.SKIP.name:
-                n.attr["style"] = "filled"
-                n.attr["fillcolor"] = "#cccccc"
-                n.attr["opacity"] = "1"
-                n.attr["fontcolor"] = "white"
-                n.attr["fontname"] = "Helvetica-Bold"
+                style.update(style="filled", fillcolor="#cccccc", opacity="1", fontcolor="white", fontname="Helvetica-Bold")
+
+            label = attrs.get("label", node_id)
+            dot.node(node_id, label=label, **style)
 
     @staticmethod
-    def _style_edges(A: Any, G: nx.DiGraph, status_dict: dict[str, str]) -> None:
+    def _style_edges(dot: Any, G: nx.DiGraph, status_dict: dict[str, str]) -> None:
         """
         Apply visual styles to graph edges based on the execution status of their source node.
 
-        :param A: AGraph (pygraphviz) instance to style.
+        :param dot: graphviz.Digraph instance to add edges to.
         :param G: NetworkX DiGraph with edge data.
         :param status_dict: Mapping of node id -> status string ("PASS", "FAIL", "SKIP").
         """
         for source, target in G.edges():
             status = status_dict.get(source, "UNKNOWN")
             logging.info("Setting edge color for %s -> %s with status %s", source, target, status)
-            e = A.get_edge(source, target)
             if status == StatusType.PASS.name:
-                e.attr["color"] = "black"
+                dot.edge(source, target, color="black")
             elif status == StatusType.FAIL.name:
-                e.attr["color"] = "red"
+                dot.edge(source, target, color="red")
             elif status == StatusType.SKIP.name:
-                e.attr["color"] = "#cccccc"
-                e.attr["opacity"] = "1"
+                dot.edge(source, target, color="#cccccc", opacity="1")
             else:
-                e.attr["color"] = "gray"
+                dot.edge(source, target, color="gray")

--- a/src/jpipe_runner/framework/engine.py
+++ b/src/jpipe_runner/framework/engine.py
@@ -603,7 +603,13 @@ class PipelineEngine:
         self._style_nodes(dot, G, status_dict)
         self._style_edges(dot, G, status_dict)
 
-        dot.render(str(resolved_path), format=format, engine="dot", cleanup=True)
+        dot.render(
+            str(resolved_path),
+            format=format,
+            engine="dot",
+            cleanup=True,
+            outfile=str(resolved_path.with_suffix(f".{format}")),
+        )
 
     @staticmethod
     def _resolve_output_path(output_path: str, filename: str) -> Path:

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -2,7 +2,7 @@
 source-dir = src
 Suite=jammy
 Package=jpipe-runner
-Depends=python3, python3-networkx, python3-pygraphviz, python3-yaml
+Depends=python3, python3-networkx, python3-graphviz, python3-yaml
 
 [debian]
 BuildDepends=debhelper (= 13), dh-python, python3-all, python3-setuptools

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -291,5 +291,73 @@ def test_justify_dry_run_and_normal(sample_justification):
     assert any(r["status"] == StatusType.FAIL for r in results)
 
 
+class TestStyleNodes:
+    def _make_graph(self, nodes):
+        G = nx.DiGraph()
+        for node in nodes:
+            G.add_node(node["id"], **node)
+        return G
+
+    def _run(self, nodes, status_dict=None):
+        import graphviz as gv
+        dot = gv.Digraph()
+        G = self._make_graph(nodes)
+        PipelineEngine._style_nodes(dot, G, status_dict or {})
+        return dot.source
+
+    # --- label rendering ---
+
+    def test_label_from_attrs_appears_in_dot_source(self):
+        source = self._run([{"id": "e1", "type": "evidence", "label": "My Evidence"}])
+        assert "My Evidence" in source
+
+    def test_label_falls_back_to_node_id_when_missing(self):
+        source = self._run([{"id": "e1", "type": "evidence"}])
+        assert "e1" in source
+
+    def test_all_node_labels_present(self):
+        nodes = [
+            {"id": "n1", "type": "evidence", "label": "Evidence Label"},
+            {"id": "n2", "type": "strategy", "label": "Strategy Label"},
+            {"id": "n3", "type": "conclusion", "label": "Conclusion Label"},
+        ]
+        source = self._run(nodes)
+        assert "Evidence Label" in source
+        assert "Strategy Label" in source
+        assert "Conclusion Label" in source
+
+    def test_label_attribute_is_set_in_dot_source(self):
+        source = self._run([{"id": "e1", "type": "evidence", "label": "Human Readable Name"}])
+        assert 'label="Human Readable Name"' in source or "label=Human Readable Name" in source
+
+    # --- node styles aligned with Java reference ---
+
+    def test_conclusion_style(self):
+        source = self._run([{"id": "c1", "type": "conclusion", "label": "C"}])
+        assert "rect" in source
+        assert "filled,rounded" in source
+        assert "lightgrey" in source
+
+    def test_sub_conclusion_style(self):
+        source = self._run([{"id": "sc1", "type": "sub-conclusion", "label": "SC"}])
+        assert "rect" in source
+        assert "#0072B2" in source
+
+    def test_strategy_style(self):
+        source = self._run([{"id": "s1", "type": "strategy", "label": "S"}])
+        assert "hexagon" in source
+        assert "#F0C27F" in source
+
+    def test_evidence_style(self):
+        source = self._run([{"id": "ev1", "type": "evidence", "label": "E"}])
+        assert "note" in source
+        assert "#9ECAE1" in source
+
+    def test_support_style(self):
+        source = self._run([{"id": "sup1", "type": "support", "label": "Sup"}])
+        assert "rect" in source
+        assert "dotted" in source
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
This pull request migrates the graph rendering backend from `pygraphviz` to the pure-Python `graphviz` package, simplifying system dependencies and aligning the code with the new backend. It updates the dependency list, refactors the rendering logic, and adjusts CI, packaging, and documentation accordingly. Additionally, new tests are added to ensure correct node label and style rendering.

**Dependency and Packaging Changes:**

* Replaces the `pygraphviz` dependency with `graphviz` in `pyproject.toml` and updates the package version to `3.3.0`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L25-R25) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3)
* Updates all CI and packaging scripts (`.github/workflows/ci.yml`, `.github/workflows/release.yml`, `action.yml`, `stdeb.cfg`, and `script/build-deb.sh`) to remove references to `pygraphviz` and related build dependencies, requiring only the `graphviz` binary and Python package. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL54-R54) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L89-R89) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L147-R142) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L214-R204) [[5]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L278-R263) [[6]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L412-R392) [[7]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L79-R79) [[8]](diffhunk://#diff-aa574ae0e7c34331f294e51e54f5080d91890de1618c6c651402fd8881ae58e6L5-R5) [[9]](diffhunk://#diff-e829870a02b9895c79b285741d97b8097485bf45962f29d88b9bc742587768caL65-R67)

**Documentation Updates:**

* Updates `CLAUDE.md` to clarify that only the `graphviz` binary is needed, not C headers or development libraries, reflecting the move away from `pygraphviz`.

**Core Rendering Refactor:**

* Refactors `PipelineEngine.export_to_format` and related methods in `src/jpipe_runner/framework/engine.py` to use `graphviz.Digraph` for graph rendering, and updates node and edge styling logic to match the new backend and align with the Java reference implementation. [[1]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366L595-R606) [[2]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366L626-R673)

**Testing Improvements:**

* Adds a new test class `TestStyleNodes` in `tests/unit/test_engine.py` to verify that node labels and styles are correctly rendered in the output DOT source, ensuring feature parity and correctness after the backend migration.