### PR TITLE
Add jpipe_link decorator for explicit function binding to pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jpipe-runner"
-version = "3.3.0"
+version = "3.4.0"
 description = "A Justification Runner designed for jPipe."
 authors = [
     "Jason Lyu <xjasonlyu@gmail.com>",

--- a/src/jpipe_runner/framework/decorators/__init__.py
+++ b/src/jpipe_runner/framework/decorators/__init__.py
@@ -1,0 +1,3 @@
+from jpipe_runner.framework.decorators.link_decorator import jpipe_link
+
+__all__ = ["jpipe_link"]

--- a/src/jpipe_runner/framework/decorators/jpipe_decorator.py
+++ b/src/jpipe_runner/framework/decorators/jpipe_decorator.py
@@ -5,6 +5,7 @@ from functools import wraps
 from typing import Any, Callable, List, Optional
 
 from jpipe_runner.framework.context import RuntimeContext, ctx
+from jpipe_runner.framework.decorators.link_decorator import jpipe_link  # noqa: F401
 from jpipe_runner.framework.logger import GLOBAL_LOGGER
 
 

--- a/src/jpipe_runner/framework/decorators/link_decorator.py
+++ b/src/jpipe_runner/framework/decorators/link_decorator.py
@@ -1,0 +1,31 @@
+from typing import Callable
+
+
+def jpipe_link(element_id: str) -> Callable:
+    """
+    Decorator to explicitly bind a Python function to a JSON pipeline element by its id.
+
+    This removes the fragile label-to-function-name mapping: instead of requiring
+    the function name to match the sanitized form of the JSON label, the decorator
+    records the element id directly on the function.
+
+    Compatible with @jpipe, @skip, and @contribution in any stacking order, because
+    all three use @wraps which propagates __dict__ attributes to their wrappers.
+
+    :param element_id: The id of the JSON element this function implements (e.g. "E1").
+    :type element_id: str
+
+    Example::
+
+        @jpipe_link("E1")
+        @jpipe(consume=["file_path"], produce=["file_exists"])
+        def check_file(file_path, produce):
+            produce("file_exists", os.path.isfile(file_path))
+            return True
+    """
+
+    def decorator(func: Callable) -> Callable:
+        func.__jpipe_link_id__ = element_id
+        return func
+
+    return decorator

--- a/src/jpipe_runner/framework/decorators/link_decorator.py
+++ b/src/jpipe_runner/framework/decorators/link_decorator.py
@@ -1,7 +1,9 @@
-from typing import Callable
+from typing import Callable, TypeVar
+
+F = TypeVar("F", bound=Callable)
 
 
-def jpipe_link(element_id: str) -> Callable:
+def jpipe_link(element_id: str) -> Callable[[F], F]:
     """
     Decorator to explicitly bind a Python function to a JSON pipeline element by its id.
 
@@ -24,7 +26,7 @@ def jpipe_link(element_id: str) -> Callable:
             return True
     """
 
-    def decorator(func: Callable) -> Callable:
+    def decorator(func: F) -> F:
         func.__jpipe_link_id__ = element_id
         return func
 

--- a/src/jpipe_runner/framework/engine.py
+++ b/src/jpipe_runner/framework/engine.py
@@ -312,7 +312,12 @@ class PipelineEngine:
                 cycle = None
 
             if cycle:
-                cycle_labels = [self.graph.nodes[n].get("label", self._qualified_id(n)) for n in cycle]
+                cycle_labels = [
+                    f"{label} ({self._qualified_id(n)})"
+                    if (label := self.graph.nodes[n].get("label"))
+                    else self._qualified_id(n)
+                    for n in cycle
+                ]
                 error_msg = (
                     "[ExecutionOrder]\n"
                     "Pipeline validation error: cycle detected in justification graph.\n"

--- a/src/jpipe_runner/framework/engine.py
+++ b/src/jpipe_runner/framework/engine.py
@@ -312,7 +312,7 @@ class PipelineEngine:
                 cycle = None
 
             if cycle:
-                cycle_labels = [self.graph.nodes[n].get("label", n) for n in cycle]
+                cycle_labels = [self.graph.nodes[n].get("label", self._qualified_id(n)) for n in cycle]
                 error_msg = (
                     "[ExecutionOrder]\n"
                     "Pipeline validation error: cycle detected in justification graph.\n"
@@ -358,6 +358,8 @@ class PipelineEngine:
         """
         GLOBAL_LOGGER.info("Running pipeline...")
 
+        self._apply_link_registry(runtime.build_link_registry())
+
         if not self._validate_pipeline():
             return
 
@@ -367,6 +369,52 @@ class PipelineEngine:
 
         for node in execution_order:
             yield self._process_node(node, runtime, dry_run)
+
+    def _apply_link_registry(self, registry: dict[str, str]) -> None:
+        """
+        Override the stored function_name for nodes that have an explicit @jpipe_link binding.
+
+        Called before validation so that all downstream lookups (skip checks, contribution
+        lookups, function dispatch) use the correct function name instead of the sanitized label.
+
+        Supports two id formats:
+        - Plain element id:              ``"e1"``
+        - Qualified id with justification name: ``"performant:e1"``
+
+        :param registry: Mapping of link_id → attr_name produced by runtime.build_link_registry().
+        :type registry: dict[str, str]
+        """
+        for link_id, attr_name in registry.items():
+            node_id = self._resolve_node_id(link_id)
+            if node_id is not None:
+                GLOBAL_LOGGER.debug(
+                    "Linking node '%s' to function '%s' via @jpipe_link.", node_id, attr_name
+                )
+                self.graph.nodes[node_id]["function_name"] = attr_name
+
+    def _qualified_id(self, node_id: str) -> str:
+        """Return the fully qualified node id (``justification_name:node_id``)."""
+        return f"{self.justification_name}:{node_id}"
+
+    def _resolve_node_id(self, link_id: str) -> str | None:
+        """
+        Resolve a @jpipe_link id to a graph node id.
+
+        Accepts plain ids (``"e1"``) or qualified ids (``"justification_name:e1"``).
+        For qualified ids the justification-name prefix must match this pipeline's name.
+
+        :param link_id: The id value passed to @jpipe_link.
+        :type link_id: str
+        :return: The matching graph node id, or None if not found.
+        :rtype: str | None
+        """
+        if link_id in self.graph.nodes:
+            return link_id
+        if ":" in link_id:
+            qualifier, element_id = link_id.rsplit(":", 1)
+            if qualifier == self.justification_name and element_id in self.graph.nodes:
+                return element_id
+        return None
 
     def _validate_pipeline(self) -> bool:
         """
@@ -417,7 +465,7 @@ class PipelineEngine:
         node_data = self.graph.nodes[node]
         node_type = node_data.get("type")
         label = node_data.get("label")
-        fn_name = sanitize_string(label)
+        fn_name = node_data.get("function_name")
         exception = None
 
         GLOBAL_LOGGER.debug("Processing node: %s", node)
@@ -428,7 +476,7 @@ class PipelineEngine:
             status = StatusType.SKIP
             exception = skip_config.get("reason", "Skipped by context")
             GLOBAL_LOGGER.info(
-                f"Skipping function '{fn_name}' for node '{node}' due to context: {exception}"
+                f"Skipping function '{fn_name}' for node '{self._qualified_id(node)}' due to context: {exception}"
             )
 
         # --- Check if predecessor failure or implicit skip should block execution ---
@@ -483,8 +531,7 @@ class PipelineEngine:
         for pred in self.graph.predecessors(node):
             pred_data = self.graph.nodes[pred]
             status = pred_data.get("status")
-            pred_label = pred_data.get("label")
-            fn_name = sanitize_string(pred_label)
+            fn_name = pred_data.get("function_name")
 
             if status is None or status == StatusType.FAIL:
                 return True
@@ -524,14 +571,14 @@ class PipelineEngine:
             if not isinstance(result, bool):
                 raise FunctionException(
                     f"Function '{fn_name}' returned an unexpected type: {type(result).__name__}.\n"
-                    f"  - The function associated with node '{node}' (label: '{label}') must return either True or False.\n"
+                    f"  - The function associated with node '{self._qualified_id(node)}' (label: '{label}') must return either True or False.\n"
                     f"  - Received: {result!r} ({type(result).__name__})\n"
                     f"  - Please ensure the function implementation returns a boolean to indicate pass/fail status correctly."
                 )
             if not result:
                 raise FunctionException(
                     f"\nFunction '{fn_name}' returned False, indicating failure.\n"
-                    f"  - The function associated with node '{node}' (label: '{label}') executed but did not pass its check.\n"
+                    f"  - The function associated with node '{self._qualified_id(node)}' (label: '{label}') executed but did not pass its check.\n"
                     f"  - Please review the implementation and input data for this function.\n"
                     f"  - Returned value: {result!r}\n"
                     f"  - The function must return True to indicate a successful check."

--- a/src/jpipe_runner/runner.py
+++ b/src/jpipe_runner/runner.py
@@ -12,7 +12,6 @@ import logging
 import os
 import shutil
 import sys
-import textwrap
 from typing import Iterable
 
 from jpipe_runner.enums import StatusType
@@ -173,18 +172,15 @@ def pretty_display(diagrams: Iterable[tuple[str, Iterable[dict]]]) -> tuple[int,
             exception = data.get("exception")
             status = data["status"]
             status_bar = f"| {colored_statuses[status]} |"
-            status_bar_len = len(status_bar)
+            status_bar_visual_len = len(f"| {status.value} |")
 
-            # Format and wrap the main line
-            line_prefix = f"{var_type}<{var_name}> :: "
+            # Format the main line, truncating with "..." if it exceeds available width
+            line_prefix = f"{var_type}<{name}:{var_name}> :: "
             full_line = f"{line_prefix}{label}"
-            wrapped_label_lines = textwrap.wrap(full_line, width=width - status_bar_len - 1)
-
-            for i, line in enumerate(wrapped_label_lines):
-                if i == 0:
-                    print(line.ljust(width - status_bar_len) + status_bar)
-                else:
-                    print(line.ljust(width))
+            max_content = width - status_bar_visual_len - 1
+            if len(full_line) > max_content:
+                full_line = full_line[: max_content - 3] + "..."
+            print(full_line.ljust(width - status_bar_visual_len) + status_bar)
 
             if exception:
                 GLOBAL_LOGGER.warning(exception)

--- a/src/jpipe_runner/runner.py
+++ b/src/jpipe_runner/runner.py
@@ -179,7 +179,12 @@ def pretty_display(diagrams: Iterable[tuple[str, Iterable[dict]]]) -> tuple[int,
             full_line = f"{line_prefix}{label}"
             max_content = width - status_bar_visual_len - 1
             if len(full_line) > max_content:
-                full_line = full_line[: max_content - 3] + "..."
+                if max_content <= 0:
+                    full_line = ""
+                elif max_content <= 3:
+                    full_line = "..."[:max_content]
+                else:
+                    full_line = full_line[: max_content - 3] + "..."
             print(full_line.ljust(width - status_bar_visual_len) + status_bar)
 
             if exception:

--- a/src/jpipe_runner/runtime.py
+++ b/src/jpipe_runner/runtime.py
@@ -128,6 +128,11 @@ class PythonRuntime:
             for attr_name in dir(module):
                 obj = getattr(module, attr_name, None)
                 if callable(obj) and (eid := getattr(obj, "__jpipe_link_id__", None)):
+                    if eid in registry and registry[eid] != attr_name:
+                        raise RuntimeException(
+                            f"Duplicate @jpipe_link id '{eid}': bound to both "
+                            f"'{registry[eid]}' and '{attr_name}'"
+                        )
                     registry[eid] = attr_name
         return registry
 

--- a/src/jpipe_runner/runtime.py
+++ b/src/jpipe_runner/runtime.py
@@ -115,6 +115,22 @@ class PythonRuntime:
         with group_github_logs():
             return self.__getattr__(name)(*args, **kwargs)
 
+    def build_link_registry(self) -> dict[str, str]:
+        """
+        Scan all loaded modules and return a mapping of element id to attribute name
+        for every callable decorated with @jpipe_link.
+
+        :return: Dict mapping element_id → attr_name in the loaded modules.
+        :rtype: dict[str, str]
+        """
+        registry = {}
+        for module in self._modules:
+            for attr_name in dir(module):
+                obj = getattr(module, attr_name, None)
+                if callable(obj) and (eid := getattr(obj, "__jpipe_link_id__", None)):
+                    registry[eid] = attr_name
+        return registry
+
     def set_variable(self, name: str, value: Any) -> None:
         """
         Set a variable with the given name and value in all modules where it exists.

--- a/tests/unit/test_link_decorator.py
+++ b/tests/unit/test_link_decorator.py
@@ -1,11 +1,7 @@
-import importlib
 import json
 import os
-import sys
 import tempfile
 import unittest
-
-import networkx as nx
 
 from jpipe_runner.framework.context import ctx
 from jpipe_runner.framework.decorators.link_decorator import jpipe_link

--- a/tests/unit/test_link_decorator.py
+++ b/tests/unit/test_link_decorator.py
@@ -1,0 +1,186 @@
+import importlib
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+import networkx as nx
+
+from jpipe_runner.framework.context import ctx
+from jpipe_runner.framework.decorators.link_decorator import jpipe_link
+from jpipe_runner.framework.decorators.jpipe_decorator import jpipe
+from jpipe_runner.framework.engine import PipelineEngine
+from jpipe_runner.runtime import PythonRuntime
+
+
+class TestJpipeLinkDecorator(unittest.TestCase):
+    def test_sets_link_id_on_plain_function(self):
+        @jpipe_link("E1")
+        def my_func():
+            return True
+
+        self.assertEqual(my_func.__jpipe_link_id__, "E1")
+
+    def test_returns_original_function_unchanged(self):
+        def my_func():
+            return 42
+
+        decorated = jpipe_link("E1")(my_func)
+        self.assertIs(decorated, my_func)
+        self.assertEqual(decorated(), 42)
+
+    def test_link_id_propagates_through_jpipe_inner(self):
+        ctx_backup = ctx._vars.copy()
+        ctx._vars.clear()
+        try:
+            @jpipe(consume=[], produce=[])
+            @jpipe_link("E1")
+            def my_func():
+                return True
+
+            self.assertEqual(my_func.__jpipe_link_id__, "E1")
+        finally:
+            ctx._vars = ctx_backup
+
+    def test_link_id_propagates_through_jpipe_outer(self):
+        ctx_backup = ctx._vars.copy()
+        ctx._vars.clear()
+        try:
+            @jpipe_link("E1")
+            @jpipe(consume=[], produce=[])
+            def my_func():
+                return True
+
+            self.assertEqual(my_func.__jpipe_link_id__, "E1")
+        finally:
+            ctx._vars = ctx_backup
+
+    def test_function_name_preserved_after_decoration(self):
+        ctx_backup = ctx._vars.copy()
+        ctx._vars.clear()
+        try:
+            @jpipe_link("E1")
+            @jpipe(consume=[], produce=[])
+            def my_function():
+                return True
+
+            self.assertEqual(my_function.__name__, "my_function")
+        finally:
+            ctx._vars = ctx_backup
+
+
+class TestBuildLinkRegistry(unittest.TestCase):
+    def _write_module(self, tmp_dir, filename, code):
+        path = os.path.join(tmp_dir, filename)
+        with open(path, "w") as f:
+            f.write(code)
+        return path
+
+    def test_returns_empty_dict_when_no_links(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write_module(tmp, "no_links.py", "def plain(): return True\n")
+            runtime = PythonRuntime(libraries=[path])
+            self.assertEqual(runtime.build_link_registry(), {})
+
+    def test_returns_correct_mapping(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            code = (
+                "from jpipe_runner.framework.decorators.link_decorator import jpipe_link\n"
+                "@jpipe_link('E1')\n"
+                "def evidence_one(): return True\n"
+            )
+            path = self._write_module(tmp, "linked.py", code)
+            runtime = PythonRuntime(libraries=[path])
+            registry = runtime.build_link_registry()
+            self.assertEqual(registry, {"E1": "evidence_one"})
+
+    def test_multiple_linked_functions(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            code = (
+                "from jpipe_runner.framework.decorators.link_decorator import jpipe_link\n"
+                "@jpipe_link('E1')\n"
+                "def func_a(): return True\n"
+                "@jpipe_link('S2')\n"
+                "def func_b(): return True\n"
+            )
+            path = self._write_module(tmp, "multi.py", code)
+            runtime = PythonRuntime(libraries=[path])
+            registry = runtime.build_link_registry()
+            self.assertEqual(registry, {"E1": "func_a", "S2": "func_b"})
+
+
+class TestApplyLinkRegistry(unittest.TestCase):
+    def _make_engine(self, tmp_path):
+        data = {
+            "name": "test",
+            "type": "justification",
+            "elements": [
+                {"id": "E1", "type": "evidence", "label": "Some Label That Wont Match"},
+                {"id": "C1", "type": "conclusion", "label": "Done"},
+            ],
+            "relations": [{"source": "E1", "target": "C1"}],
+        }
+        path = os.path.join(tmp_path, "j.json")
+        with open(path, "w") as f:
+            json.dump(data, f)
+        from unittest.mock import patch
+        with patch("jpipe_runner.framework.engine.PipelineEngine.load_config"):
+            engine = PipelineEngine(None, path)
+        return engine
+
+    def test_updates_function_name_for_linked_node(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            engine._apply_link_registry({"E1": "my_custom_function"})
+            self.assertEqual(engine.graph.nodes["E1"]["function_name"], "my_custom_function")
+
+    def test_unlinked_node_keeps_sanitized_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            engine._apply_link_registry({"E1": "my_custom_function"})
+            # C1 is not in the registry — its function_name should still be the sanitized label
+            self.assertEqual(engine.graph.nodes["C1"]["function_name"], "done")
+
+    def test_unknown_node_id_in_registry_is_ignored(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            # Should not raise even for ids not in the graph
+            engine._apply_link_registry({"NONEXISTENT": "some_func"})
+            self.assertNotIn("NONEXISTENT", engine.graph.nodes)
+
+    def test_qualified_id_format_resolves_correctly(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            # "test:E1" should resolve to node "E1" when justification name is "test"
+            engine._apply_link_registry({"test:E1": "my_custom_function"})
+            self.assertEqual(engine.graph.nodes["E1"]["function_name"], "my_custom_function")
+
+    def test_qualified_id_wrong_justification_is_ignored(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            original = engine.graph.nodes["E1"]["function_name"]
+            # Wrong justification name — should not update the node
+            engine._apply_link_registry({"other_pipeline:E1": "my_custom_function"})
+            self.assertEqual(engine.graph.nodes["E1"]["function_name"], original)
+
+    def test_resolve_node_id_plain(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            self.assertEqual(engine._resolve_node_id("E1"), "E1")
+
+    def test_resolve_node_id_qualified(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            self.assertEqual(engine._resolve_node_id("test:E1"), "E1")
+
+    def test_resolve_node_id_unknown(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            self.assertIsNone(engine._resolve_node_id("MISSING"))
+            self.assertIsNone(engine._resolve_node_id("test:MISSING"))
+            self.assertIsNone(engine._resolve_node_id("other:E1"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces the new `@jpipe_link` decorator, which allows explicit binding of Python functions to pipeline element IDs, removing the need for fragile label-to-function-name mapping. The changes include the implementation of the decorator, integration into the runtime and pipeline engine, and comprehensive unit tests to ensure correct behavior. Additionally, there are improvements to error messages and display formatting.

### New Feature: Explicit Function-to-Element Binding

* Added the `@jpipe_link` decorator (`link_decorator.py`) that allows developers to explicitly associate a function with a pipeline element by its ID, making the mapping robust and decoupled from function names.
* Updated the pipeline execution logic to use the `function_name` set by `@jpipe_link` (instead of sanitized labels) throughout node processing, error reporting, and skip checks (`engine.py`). [[1]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366L420-R468) [[2]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366L431-R479) [[3]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366L486-R534) [[4]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366L527-R581)

### Runtime and Engine Integration

* Implemented `build_link_registry` in `PythonRuntime` to scan loaded modules for functions decorated with `@jpipe_link`, returning a mapping of element IDs to function names.
* Added `_apply_link_registry`, `_qualified_id`, and `_resolve_node_id` methods to `PipelineEngine` to update graph nodes with the correct function bindings before validation and execution. [[1]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366R361-R362) [[2]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366R373-R418)

### Testing

* Added comprehensive unit tests for the new decorator, registry building, and engine integration, covering various usage scenarios and edge cases (`test_link_decorator.py`).

### Other Improvements

* Improved error and log messages to use qualified node IDs, making debugging clearer. [[1]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366L315-R315) [[2]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366L527-R581)
* Enhanced the pretty display output to include the justification name in the variable display and improved line truncation logic (`runner.py`).

### Maintenance

* Bumped the package version to `3.4.0` in `pyproject.toml`.
* Minor cleanup (removed unused imports, updated `__init__.py` for decorator exports). [[1]](diffhunk://#diff-ac0621dc17c3fb4cfd6c13823f9adf1b64d116f381bb865378cd7f365b2de9b9L15) [[2]](diffhunk://#diff-2ae28a8d74266ba9ffdd45eeca7dc5433963df2af6088f6c896770db8155a871R1-R3) [[3]](diffhunk://#diff-5b3efd5683b60d10191b714b2b765adbad28ea1be4cce1d306661b91bdc61f1fR8)

These changes make function-to-element mapping more robust, improve maintainability, and provide thorough test coverage for the new behavior.…s by id

Replaces the fragile label-sanitisation mapping with an explicit binding: @jpipe_link("justification:element_id") on a Python function pins it to the corresponding JSON element regardless of function name or label wording.

- New decorator jpipe_link() sets __jpipe_link_id__ on the function and propagates correctly through @jpipe / @skip / @contribution in any stacking order (functools.wraps copies __dict__)
- PythonRuntime.build_link_registry() scans loaded modules for linked fns
- PipelineEngine._apply_link_registry() / _resolve_node_id() resolve both plain ("e1") and qualified ("performant:e1") id formats before validation
- All user-facing node references now use the fully qualified id via _qualified_id() helper (error messages, skip logs, cycle reports)
- Report display uses justification_name:element_id format and a single truncated line per node (fixes ANSI-inflated status-bar width calculation)
- jpipe_link re-exported from jpipe_decorator for backward compatibility