### PR TITLE
cicd/add dev branch to CI push trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - dev
 
 jobs:
   test:


### PR DESCRIPTION
### Goal
Extend the CI workflow to run on pushes to the `dev` branch, in addition to the existing `main` branch.

### Description
Currently, `ci.yml` triggers only on pushes to `main`:
```yaml
on:
  push:
    branches:
      - main
```

### Acceptance Criteria
* [x] The `push.branches` list in `ci.yml` includes `dev`.