### PR TITLE
fix/remove unsupported deprecated parameter from AppendElseDefaultAction

### DIFF
--- a/src/jpipe_runner/utils/append_else_default_action.py
+++ b/src/jpipe_runner/utils/append_else_default_action.py
@@ -21,7 +21,6 @@ class AppendElseDefaultAction(Action):
         required=False,
         help=None,
         metavar=None,
-        deprecated=False,
     ):
         if nargs == 0:
             raise ValueError(
@@ -48,7 +47,6 @@ class AppendElseDefaultAction(Action):
             required=required,
             help=help,
             metavar=metavar,
-            deprecated=deprecated,
         )
 
     def __call__(self, parser, namespace, values, option_string=None):


### PR DESCRIPTION
### Goal
Ensure the custom `AppendElseDefaultAction` works across all supported Python versions by removing the `deprecated` parameter, which is not present in older argparse implementations.

### Description
The constructor of `AppendElseDefaultAction` currently accepts and forwards a `deprecated` keyword argument:
```python
def __init__(self, ..., deprecated=False):
    super().__init__(..., deprecated=deprecated)
```

### Acceptance Criteria
* [x] The `deprecated` parameter is removed from `AppendElseDefaultAction.__init__`.
* [x] The call to `super().__init__` no longer passes `deprecated`.
* [x] Existing unit tests for the action still pass.