### PR TITLE
Enhance CI triggers, fix import issues, and improve alias handling

### DIFF
--- a/src/jpipe_runner/framework/decorators/link_decorator.py
+++ b/src/jpipe_runner/framework/decorators/link_decorator.py
@@ -11,15 +11,22 @@ def jpipe_link(element_id: str) -> Callable[[F], F]:
     the function name to match the sanitized form of the JSON label, the decorator
     records the element id directly on the function.
 
+    The decorator may be stacked multiple times to bind one function to several
+    names — all expected to be aliases of the same unified node. Each application
+    appends to the ``__jpipe_link_ids__`` list rather than overwriting, so no
+    binding is silently lost.
+
     Compatible with @jpipe, @skip, and @contribution in any stacking order, because
     all three use @wraps which propagates __dict__ attributes to their wrappers.
 
-    :param element_id: The id of the JSON element this function implements (e.g. "E1").
+    :param element_id: The id (or alias) of the JSON element this function implements
+        (e.g. "E1" or "rigor:r17:e_metric").
     :type element_id: str
 
     Example::
 
-        @jpipe_link("E1")
+        @jpipe_link("rigor:r17:e_metric")
+        @jpipe_link("rigor:r18:e")
         @jpipe(consume=["file_path"], produce=["file_exists"])
         def check_file(file_path, produce):
             produce("file_exists", os.path.isfile(file_path))
@@ -27,7 +34,11 @@ def jpipe_link(element_id: str) -> Callable[[F], F]:
     """
 
     def decorator(func: F) -> F:
-        func.__jpipe_link_id__ = element_id
+        ids = getattr(func, "__jpipe_link_ids__", None)
+        if ids is None:
+            ids = []
+            func.__jpipe_link_ids__ = ids
+        ids.append(element_id)
         return func
 
     return decorator

--- a/src/jpipe_runner/framework/engine.py
+++ b/src/jpipe_runner/framework/engine.py
@@ -5,7 +5,7 @@ import networkx as nx
 import yaml
 
 from ..enums import StatusType
-from ..exceptions import FunctionException
+from ..exceptions import FunctionException, RuntimeException
 from ..runtime import PythonRuntime
 from ..utils.parsing import normalize_structure, parse_value
 from ..utils.sanitize import sanitize_string
@@ -60,6 +60,8 @@ class PipelineEngine:
         GLOBAL_LOGGER.info("Initializing PipelineEngine...")
         self.justification_name = "Unknown Justification"
         self._link_registry: dict[str, str] = {}
+        # Maps each node id and each of its aliases → the canonical node id.
+        self._alias_index: dict[str, str] = {}
         self.load_config(config_path, variables)
         if justification_path:
             self.graph = self.parse_justification(justification_path)
@@ -203,9 +205,17 @@ class PipelineEngine:
         :return: True on success, False on KeyError.
         """
         try:
+            self._alias_index = {}
             for element in data.get("elements", []):
                 G.add_node(element["id"], **element)
-                G.nodes[element["id"]]["function_name"] = sanitize_string(element.get("label", ""))
+                G.nodes[element["id"]]["function_name"] = sanitize_string(
+                    element.get("label", "")
+                )
+                # Index the canonical id and every alias to the canonical id, so a
+                # @jpipe_link decorated with either resolves to this node.
+                self._alias_index[element["id"]] = element["id"]
+                for alias in element.get("aliases", []):
+                    self._alias_index[alias] = element["id"]
             return True
         except KeyError as e:
             GLOBAL_LOGGER.error("Missing required key in justification elements: %s", e)
@@ -270,7 +280,7 @@ class PipelineEngine:
             ProducedButNotConsumedValidator(self, ctx),
             DuplicateProducerValidator(self, ctx),
             EvidenceDependencyValidator(self, ctx, self.graph),
-            UnboundElementValidator(self, ctx, self._link_registry),
+            UnboundElementValidator(self, ctx),
         ]
 
         all_passed = True
@@ -383,8 +393,9 @@ class PipelineEngine:
         Called before validation so that all downstream lookups (skip checks, contribution
         lookups, function dispatch) use the correct function name instead of the sanitized label.
 
-        Supports two id formats:
-        - Plain element id:              ``"e1"``
+        Supports three id formats (see :meth:`_resolve_node_id`):
+        - Plain element id:                     ``"e1"``
+        - Node alias (incl. colon-bearing):     ``"rigor:r17:e_metric"``
         - Qualified id with justification name: ``"performant:e1"``
 
         :param registry: Mapping of link_id → attr_name produced by runtime.build_link_registry().
@@ -407,14 +418,21 @@ class PipelineEngine:
         """
         Resolve a @jpipe_link id to a graph node id.
 
-        Accepts plain ids (``"e1"``) or qualified ids (``"justification_name:e1"``).
-        For qualified ids the justification-name prefix must match this pipeline's name.
+        Resolution order:
+        1. Exact match against the alias index — covers both canonical node ids and
+           aliases, including colon-bearing aliases (``"rigor:r17:e_metric"``). This
+           is tried first so aliases never fall through to the qualified-id splitter.
+        2. Plain id present as a graph node (``"e1"``).
+        3. Qualified id (``"justification_name:e1"``) whose prefix matches this
+           pipeline's name.
 
         :param link_id: The id value passed to @jpipe_link.
         :type link_id: str
         :return: The matching graph node id, or None if not found.
         :rtype: str | None
         """
+        if link_id in self._alias_index:
+            return self._alias_index[link_id]
         if link_id in self.graph.nodes:
             return link_id
         if ":" in link_id:
@@ -422,6 +440,33 @@ class PipelineEngine:
             if qualifier == self.justification_name and element_id in self.graph.nodes:
                 return element_id
         return None
+
+    def _bound_node_ids(self) -> set[str]:
+        """
+        Resolve every @jpipe_link registry key to its canonical graph node id and
+        return the set of node ids that carry an explicit binding.
+
+        This is the single source of truth for "is this node bound?", shared by the
+        UnboundElementValidator and the sub-conclusion execution guard.
+
+        :raises RuntimeException: If two different registry keys (e.g. two aliases of
+            the same unified node) resolve to the same node but were bound to
+            different functions — a conflicting binding.
+        :return: Set of canonical node ids that are explicitly bound.
+        :rtype: set[str]
+        """
+        bound: dict[str, str] = {}  # canonical node id → function name
+        for name, function_name in self._link_registry.items():
+            node_id = self._resolve_node_id(name)
+            if node_id is None:
+                continue
+            if node_id in bound and bound[node_id] != function_name:
+                raise RuntimeException(
+                    f"Conflicting @jpipe_link binding for node '{node_id}': "
+                    f"aliases bound to both '{bound[node_id]}' and '{function_name}'"
+                )
+            bound[node_id] = function_name
+        return set(bound)
 
     def _validate_pipeline(self) -> bool:
         """
@@ -492,11 +537,7 @@ class PipelineEngine:
 
         # --- Attempt function execution (or dry-run) ---
         elif node_type in {"evidence", "strategy"} or (
-            node_type == "sub-conclusion"
-            and (
-                node in self._link_registry
-                or f"{self.justification_name}:{node}" in self._link_registry
-            )
+            node_type == "sub-conclusion" and node in self._bound_node_ids()
         ):
             status, exception = self._execute_justification_fn(
                 label, fn_name, runtime, dry_run, node

--- a/src/jpipe_runner/framework/engine.py
+++ b/src/jpipe_runner/framework/engine.py
@@ -206,6 +206,20 @@ class PipelineEngine:
         """
         try:
             self._alias_index = {}
+
+            def _index(key: str, canonical_id: str) -> None:
+                # A key (node id or alias) must map to exactly one canonical node.
+                # A collision — an alias shared by two elements, or an alias equal
+                # to another element's id — would make _resolve_node_id() silently
+                # resolve to the wrong node, so reject it instead of last-write-wins.
+                existing = self._alias_index.get(key)
+                if existing is not None and existing != canonical_id:
+                    raise ValueError(
+                        f"Duplicate element id/alias '{key}': maps to both "
+                        f"'{existing}' and '{canonical_id}'."
+                    )
+                self._alias_index[key] = canonical_id
+
             for element in data.get("elements", []):
                 G.add_node(element["id"], **element)
                 G.nodes[element["id"]]["function_name"] = sanitize_string(
@@ -213,12 +227,15 @@ class PipelineEngine:
                 )
                 # Index the canonical id and every alias to the canonical id, so a
                 # @jpipe_link decorated with either resolves to this node.
-                self._alias_index[element["id"]] = element["id"]
+                _index(element["id"], element["id"])
                 for alias in element.get("aliases", []):
-                    self._alias_index[alias] = element["id"]
+                    _index(alias, element["id"])
             return True
         except KeyError as e:
             GLOBAL_LOGGER.error("Missing required key in justification elements: %s", e)
+            return False
+        except ValueError as e:
+            GLOBAL_LOGGER.error("Conflicting element id/alias in justification: %s", e)
             return False
 
     def _add_edges_to_graph(self, G: nx.DiGraph, data: dict) -> bool:

--- a/src/jpipe_runner/framework/validators/unbound_element.py
+++ b/src/jpipe_runner/framework/validators/unbound_element.py
@@ -1,3 +1,4 @@
+from ...exceptions import RuntimeException
 from ..logger import GLOBAL_LOGGER
 from .base import BaseValidator
 
@@ -22,7 +23,20 @@ class UnboundElementValidator(BaseValidator):
         :rtype: tuple[list[str], list[str]]
         """
         GLOBAL_LOGGER.info("Running UnboundElementValidator...")
-        bound = self.pipeline._bound_node_ids()
+        try:
+            bound = self.pipeline._bound_node_ids()
+        except RuntimeException as e:
+            # A conflicting @jpipe_link binding (e.g. two aliases of one node bound
+            # to different functions) is a user error — report it as a validation
+            # failure so the runner exits cleanly instead of raising a traceback.
+            self.errors.append(
+                "[UnboundElementValidator]\n"
+                "Pipeline validation error: conflicting @jpipe_link binding.\n"
+                f"  • Problem: {e}\n"
+                "  • Fix: Ensure all aliases of a node are bound to the same function.\n"
+            )
+            GLOBAL_LOGGER.info("UnboundElementValidator completed with 1 error(s).")
+            return self.errors, self.warnings
         for node_id, data in self.pipeline.graph.nodes(data=True):
             if data.get("type") not in self.EXECUTABLE_TYPES:
                 continue

--- a/src/jpipe_runner/framework/validators/unbound_element.py
+++ b/src/jpipe_runner/framework/validators/unbound_element.py
@@ -10,35 +10,23 @@ class UnboundElementValidator(BaseValidator):
 
     EXECUTABLE_TYPES = {"evidence", "strategy"}
 
-    def __init__(self, pipeline: "PipelineEngine", ctx: "RuntimeContext", registry: dict[str, str]) -> None:
-        """
-        Initialize the validator.
-
-        :param pipeline: The pipeline engine being validated.
-        :param ctx: The runtime context.
-        :param registry: Mapping of element_id → function_name produced by build_link_registry().
-        """
-        super().__init__(pipeline, ctx)
-        self.registry = registry
-
-    def _is_bound(self, node_id: str) -> bool:
-        return (
-            node_id in self.registry
-            or f"{self.pipeline.justification_name}:{node_id}" in self.registry
-        )
-
     def validate(self) -> tuple[list[str], list[str]]:
         """
         Validate that every executable node has an explicit @jpipe_link binding.
+
+        Binding is decided by the pipeline's alias-aware ``_bound_node_ids()`` — a
+        node counts as bound whether the @jpipe_link used its canonical id, a
+        qualified id, or one of its aliases.
 
         :return: A tuple of (errors, warnings).
         :rtype: tuple[list[str], list[str]]
         """
         GLOBAL_LOGGER.info("Running UnboundElementValidator...")
+        bound = self.pipeline._bound_node_ids()
         for node_id, data in self.pipeline.graph.nodes(data=True):
             if data.get("type") not in self.EXECUTABLE_TYPES:
                 continue
-            if not self._is_bound(node_id):
+            if node_id not in bound:
                 label = data.get("label", node_id)
                 node_type = data.get("type")
                 self.errors.append(

--- a/src/jpipe_runner/runtime.py
+++ b/src/jpipe_runner/runtime.py
@@ -132,17 +132,23 @@ class PythonRuntime:
 
     def build_link_registry(self) -> dict[str, str]:
         """
-        Scan all loaded modules and return a mapping of element id to attribute name
-        for every callable decorated with @jpipe_link.
+        Scan all loaded modules and return a mapping of element id (or alias) to
+        attribute name for every callable decorated with @jpipe_link.
 
-        :return: Dict mapping element_id → attr_name in the loaded modules.
+        A function may carry several @jpipe_link decorators (all aliases of the same
+        node); every accumulated id/alias is registered as a key pointing to the
+        same attribute name.
+
+        :return: Dict mapping element_id/alias → attr_name in the loaded modules.
         :rtype: dict[str, str]
         """
         registry = {}
         for module in self._modules:
             for attr_name in dir(module):
                 obj = getattr(module, attr_name, None)
-                if callable(obj) and (eid := getattr(obj, "__jpipe_link_id__", None)):
+                if not callable(obj):
+                    continue
+                for eid in getattr(obj, "__jpipe_link_ids__", None) or []:
                     if eid in registry and registry[eid] != attr_name:
                         raise RuntimeException(
                             f"Duplicate @jpipe_link id '{eid}': bound to both "

--- a/src/jpipe_runner/schema/justification.schema.json
+++ b/src/jpipe_runner/schema/justification.schema.json
@@ -16,6 +16,7 @@
           "label":   {"type": "string"},
           "type":    {"type": "string",
                       "enum": ["evidence", "strategy", "conclusion", "sub-conclusion"]},
+          "aliases": {"type": "array", "items": {"type": "string"}},
           "escaped": {"type": "string"}
         }
       }

--- a/tests/e2e/resources/alias_binding/metrics.json
+++ b/tests/e2e/resources/alias_binding/metrics.json
@@ -1,0 +1,23 @@
+{
+  "elements": [
+    {
+      "id": "rigor:unified_0",
+      "label": "The model reports its metrics",
+      "type": "evidence",
+      "aliases": ["rigor:r17:e_metric", "rigor:r18:e"]
+    },
+    {
+      "id": "C1",
+      "label": "Model is rigorous",
+      "type": "conclusion"
+    }
+  ],
+  "name": "alias_binding",
+  "relations": [
+    {
+      "source": "rigor:unified_0",
+      "target": "C1"
+    }
+  ],
+  "type": "justification"
+}

--- a/tests/e2e/resources/alias_binding/metrics.py
+++ b/tests/e2e/resources/alias_binding/metrics.py
@@ -1,0 +1,20 @@
+from jpipe_runner.framework.decorators.jpipe_decorator import jpipe
+from jpipe_runner.framework.decorators.link_decorator import jpipe_link
+
+
+# The unified evidence node "rigor:unified_0" is bound here by TWO of its aliases
+# (neither of which is the canonical id). This exercises both alias resolution and
+# stacking multiple @jpipe_link decorators on a single implementing function.
+@jpipe_link("rigor:r17:e_metric")
+@jpipe_link("rigor:r18:e")
+@jpipe(consume=[], produce=["metrics_reported"])
+def report_metrics(produce) -> bool:
+    """Evidence: the model reports its metrics."""
+    produce("metrics_reported", True)
+    return True
+
+
+@jpipe(consume=["metrics_reported"])
+def model_is_rigorous(metrics_reported: bool) -> bool:
+    """Conclusion: the model is rigorous when its metrics are reported."""
+    return metrics_reported

--- a/tests/e2e/test_alias_binding_e2e.py
+++ b/tests/e2e/test_alias_binding_e2e.py
@@ -1,0 +1,73 @@
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+class TestAliasBindingE2E(unittest.TestCase):
+    """
+    End-to-end tests for @jpipe_link binding on node aliases.
+
+    The justification contains a unified evidence node whose canonical id is
+    "rigor:unified_0" and which carries two aliases. The implementing function is
+    bound by *both* aliases (stacked @jpipe_link decorators), neither of which is
+    the canonical id — so the pipeline only runs clean if alias resolution and
+    multiple annotations per function both work.
+    """
+
+    def setUp(self):
+        self.test_dir = Path(__file__).parent / "resources" / "alias_binding"
+        self.justification_file = self.test_dir / "metrics.json"
+        self.python_file = self.test_dir / "metrics.py"
+        self.justification_name = "alias_binding"
+
+        self.assertTrue(
+            self.justification_file.exists(),
+            f"Justification file not found: {self.justification_file}",
+        )
+        self.assertTrue(
+            self.python_file.exists(), f"Python file not found: {self.python_file}"
+        )
+
+    def _run_jpipe_runner(self, additional_args=None, expected_exit_code=0):
+        cmd = [
+            sys.executable,
+            "-m",
+            "jpipe_runner.runner",
+            "--library",
+            str(self.python_file),
+            str(self.justification_file),
+        ]
+        if additional_args:
+            cmd.extend(additional_args)
+
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, cwd=self.test_dir.parent.parent.parent
+        )
+
+        if result.returncode != expected_exit_code:
+            print(f"STDOUT:\n{result.stdout}")
+            print(f"STDERR:\n{result.stderr}")
+            print(f"Expected exit code {expected_exit_code}, got {result.returncode}")
+
+        self.assertEqual(result.returncode, expected_exit_code)
+        return result
+
+    def test_alias_bound_pipeline_runs_and_passes(self):
+        """The alias-bound evidence node executes and the pipeline passes."""
+        result = self._run_jpipe_runner()
+        self.assertIn(self.justification_name, result.stdout.lower())
+        # The unified evidence node executed (PASS), proving alias resolution worked.
+        self.assertIn("rigor:unified_0", result.stdout)
+        self.assertEqual(result.returncode, 0)
+
+    def test_alias_bound_validation_is_clean(self):
+        """No UnboundElementValidator error for the alias-bound evidence node."""
+        result = self._run_jpipe_runner()
+        self.assertNotIn("unboundelementvalidator", result.stderr.lower())
+        self.assertNotIn("unbound pipeline element", result.stderr.lower())
+        self.assertEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_link_decorator.py
+++ b/tests/unit/test_link_decorator.py
@@ -7,6 +7,7 @@ from jpipe_runner.framework.context import ctx
 from jpipe_runner.framework.decorators.link_decorator import jpipe_link
 from jpipe_runner.framework.decorators.jpipe_decorator import jpipe
 from jpipe_runner.framework.engine import PipelineEngine
+from jpipe_runner.exceptions import RuntimeException
 from jpipe_runner.runtime import PythonRuntime
 
 
@@ -16,7 +17,19 @@ class TestJpipeLinkDecorator(unittest.TestCase):
         def my_func():
             return True
 
-        self.assertEqual(my_func.__jpipe_link_id__, "E1")
+        self.assertEqual(my_func.__jpipe_link_ids__, ["E1"])
+
+    def test_stacked_decorators_accumulate_ids(self):
+        # Two @jpipe_link decorators (aliases of the same node) must both be kept,
+        # in bottom-to-top application order, rather than the last overwriting.
+        @jpipe_link("rigor:r17:e_metric")
+        @jpipe_link("rigor:r18:e")
+        def my_func():
+            return True
+
+        self.assertEqual(
+            my_func.__jpipe_link_ids__, ["rigor:r18:e", "rigor:r17:e_metric"]
+        )
 
     def test_returns_original_function_unchanged(self):
         def my_func():
@@ -35,7 +48,7 @@ class TestJpipeLinkDecorator(unittest.TestCase):
             def my_func():
                 return True
 
-            self.assertEqual(my_func.__jpipe_link_id__, "E1")
+            self.assertEqual(my_func.__jpipe_link_ids__, ["E1"])
         finally:
             ctx._vars = ctx_backup
 
@@ -48,7 +61,25 @@ class TestJpipeLinkDecorator(unittest.TestCase):
             def my_func():
                 return True
 
-            self.assertEqual(my_func.__jpipe_link_id__, "E1")
+            self.assertEqual(my_func.__jpipe_link_ids__, ["E1"])
+        finally:
+            ctx._vars = ctx_backup
+
+    def test_stacked_alias_ids_survive_jpipe_wrapping(self):
+        # The accumulated list must remain visible after @jpipe wraps the function,
+        # because @jpipe uses @wraps which shares __dict__ references.
+        ctx_backup = ctx._vars.copy()
+        ctx._vars.clear()
+        try:
+            @jpipe_link("rigor:r17:e_metric")
+            @jpipe_link("rigor:r18:e")
+            @jpipe(consume=[], produce=[])
+            def my_func():
+                return True
+
+            self.assertEqual(
+                my_func.__jpipe_link_ids__, ["rigor:r18:e", "rigor:r17:e_metric"]
+            )
         finally:
             ctx._vars = ctx_backup
 
@@ -104,6 +135,36 @@ class TestBuildLinkRegistry(unittest.TestCase):
             runtime = PythonRuntime(libraries=[path])
             registry = runtime.build_link_registry()
             self.assertEqual(registry, {"E1": "func_a", "S2": "func_b"})
+
+    def test_stacked_aliases_emit_every_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            code = (
+                "from jpipe_runner.framework.decorators.link_decorator import jpipe_link\n"
+                "@jpipe_link('rigor:r17:e_metric')\n"
+                "@jpipe_link('rigor:r18:e')\n"
+                "def unified(): return True\n"
+            )
+            path = self._write_module(tmp, "aliased.py", code)
+            runtime = PythonRuntime(libraries=[path])
+            registry = runtime.build_link_registry()
+            self.assertEqual(
+                registry,
+                {"rigor:r17:e_metric": "unified", "rigor:r18:e": "unified"},
+            )
+
+    def test_same_name_on_two_functions_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            code = (
+                "from jpipe_runner.framework.decorators.link_decorator import jpipe_link\n"
+                "@jpipe_link('E1')\n"
+                "def func_a(): return True\n"
+                "@jpipe_link('E1')\n"
+                "def func_b(): return True\n"
+            )
+            path = self._write_module(tmp, "dup.py", code)
+            runtime = PythonRuntime(libraries=[path])
+            with self.assertRaises(RuntimeException):
+                runtime.build_link_registry()
 
 
 class TestApplyLinkRegistry(unittest.TestCase):
@@ -176,6 +237,91 @@ class TestApplyLinkRegistry(unittest.TestCase):
             self.assertIsNone(engine._resolve_node_id("MISSING"))
             self.assertIsNone(engine._resolve_node_id("test:MISSING"))
             self.assertIsNone(engine._resolve_node_id("other:E1"))
+
+
+class TestAliasResolution(unittest.TestCase):
+    def _make_engine(self, tmp_path):
+        data = {
+            "name": "rigor",
+            "type": "justification",
+            "elements": [
+                {
+                    "id": "rigor:unified_0",
+                    "type": "evidence",
+                    "label": "The model reports its metrics",
+                    "aliases": ["rigor:r17:e_metric", "rigor:r18:e"],
+                },
+                {"id": "C1", "type": "conclusion", "label": "Done"},
+            ],
+            "relations": [{"source": "rigor:unified_0", "target": "C1"}],
+        }
+        path = os.path.join(tmp_path, "j.json")
+        with open(path, "w") as f:
+            json.dump(data, f)
+        from unittest.mock import patch
+        with patch("jpipe_runner.framework.engine.PipelineEngine.load_config"):
+            engine = PipelineEngine(None, path)
+        return engine
+
+    def test_alias_index_built_for_id_and_aliases(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            self.assertEqual(engine._alias_index["rigor:unified_0"], "rigor:unified_0")
+            self.assertEqual(engine._alias_index["rigor:r17:e_metric"], "rigor:unified_0")
+            self.assertEqual(engine._alias_index["rigor:r18:e"], "rigor:unified_0")
+
+    def test_resolve_canonical_id(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            self.assertEqual(
+                engine._resolve_node_id("rigor:unified_0"), "rigor:unified_0"
+            )
+
+    def test_resolve_colon_bearing_alias(self):
+        # An alias containing colons must match exactly (not be rsplit into a bogus
+        # qualifier/element pair) and resolve to the canonical id.
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            self.assertEqual(
+                engine._resolve_node_id("rigor:r17:e_metric"), "rigor:unified_0"
+            )
+            self.assertEqual(
+                engine._resolve_node_id("rigor:r18:e"), "rigor:unified_0"
+            )
+
+    def test_apply_registry_binds_via_alias(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            engine._apply_link_registry({"rigor:r17:e_metric": "report_metrics"})
+            self.assertEqual(
+                engine.graph.nodes["rigor:unified_0"]["function_name"],
+                "report_metrics",
+            )
+
+    def test_bound_node_ids_includes_alias_only_binding(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            engine._apply_link_registry({"rigor:r18:e": "report_metrics"})
+            self.assertIn("rigor:unified_0", engine._bound_node_ids())
+
+    def test_bound_node_ids_two_aliases_same_function_ok(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            engine._apply_link_registry(
+                {"rigor:r17:e_metric": "report_metrics", "rigor:r18:e": "report_metrics"}
+            )
+            self.assertEqual(engine._bound_node_ids(), {"rigor:unified_0"})
+
+    def test_bound_node_ids_conflicting_functions_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            # Two different aliases of the SAME node bound to DIFFERENT functions.
+            engine._link_registry = {
+                "rigor:r17:e_metric": "func_a",
+                "rigor:r18:e": "func_b",
+            }
+            with self.assertRaises(RuntimeException):
+                engine._bound_node_ids()
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_link_decorator.py
+++ b/tests/unit/test_link_decorator.py
@@ -240,6 +240,14 @@ class TestApplyLinkRegistry(unittest.TestCase):
 
 
 class TestAliasResolution(unittest.TestCase):
+    def _make_engine_from(self, tmp_path, data):
+        path = os.path.join(tmp_path, "j.json")
+        with open(path, "w") as f:
+            json.dump(data, f)
+        from unittest.mock import patch
+        with patch("jpipe_runner.framework.engine.PipelineEngine.load_config"):
+            return PipelineEngine(None, path)
+
     def _make_engine(self, tmp_path):
         data = {
             "name": "rigor",
@@ -322,6 +330,77 @@ class TestAliasResolution(unittest.TestCase):
             }
             with self.assertRaises(RuntimeException):
                 engine._bound_node_ids()
+
+    def test_alias_shared_by_two_nodes_fails_parsing(self):
+        # A collision (same alias on two elements) must be rejected rather than
+        # silently resolving to whichever element was indexed last.
+        data = {
+            "name": "rigor",
+            "type": "justification",
+            "elements": [
+                {"id": "N1", "type": "evidence", "label": "One", "aliases": ["shared"]},
+                {"id": "N2", "type": "evidence", "label": "Two", "aliases": ["shared"]},
+                {"id": "C1", "type": "conclusion", "label": "Done"},
+            ],
+            "relations": [{"source": "N1", "target": "C1"}],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine_from(tmp, data)
+            # Parsing bails out, leaving an empty graph rather than a mis-indexed one.
+            self.assertEqual(engine.graph.number_of_nodes(), 0)
+
+    def test_alias_equal_to_other_node_id_fails_parsing(self):
+        data = {
+            "name": "rigor",
+            "type": "justification",
+            "elements": [
+                {"id": "N1", "type": "evidence", "label": "One", "aliases": ["N2"]},
+                {"id": "N2", "type": "evidence", "label": "Two"},
+                {"id": "C1", "type": "conclusion", "label": "Done"},
+            ],
+            "relations": [{"source": "N1", "target": "C1"}],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine_from(tmp, data)
+            self.assertEqual(engine.graph.number_of_nodes(), 0)
+
+
+class TestUnboundValidatorConflict(unittest.TestCase):
+    def test_conflicting_binding_reported_as_error_not_raised(self):
+        from jpipe_runner.framework.context import ctx as global_ctx
+        from jpipe_runner.framework.validators import UnboundElementValidator
+
+        data = {
+            "name": "rigor",
+            "type": "justification",
+            "elements": [
+                {
+                    "id": "rigor:unified_0",
+                    "type": "evidence",
+                    "label": "Metrics",
+                    "aliases": ["rigor:r17:e_metric", "rigor:r18:e"],
+                },
+                {"id": "C1", "type": "conclusion", "label": "Done"},
+            ],
+            "relations": [{"source": "rigor:unified_0", "target": "C1"}],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "j.json")
+            with open(path, "w") as f:
+                json.dump(data, f)
+            from unittest.mock import patch
+            with patch("jpipe_runner.framework.engine.PipelineEngine.load_config"):
+                engine = PipelineEngine(None, path)
+            engine._link_registry = {
+                "rigor:r17:e_metric": "func_a",
+                "rigor:r18:e": "func_b",
+            }
+
+            validator = UnboundElementValidator(engine, global_ctx)
+            # Must NOT raise; the conflict surfaces as a validation error.
+            errors, _ = validator.validate()
+            self.assertEqual(len(errors), 1)
+            self.assertIn("conflicting", errors[0].lower())
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_link_decorator.py
+++ b/tests/unit/test_link_decorator.py
@@ -2,12 +2,15 @@ import json
 import os
 import tempfile
 import unittest
+from unittest.mock import patch
 
-from jpipe_runner.framework.context import ctx
-from jpipe_runner.framework.decorators.link_decorator import jpipe_link
-from jpipe_runner.framework.decorators.jpipe_decorator import jpipe
-from jpipe_runner.framework.engine import PipelineEngine
 from jpipe_runner.exceptions import RuntimeException
+from jpipe_runner.framework.context import ctx
+from jpipe_runner.framework.context import ctx as global_ctx
+from jpipe_runner.framework.decorators.jpipe_decorator import jpipe
+from jpipe_runner.framework.decorators.link_decorator import jpipe_link
+from jpipe_runner.framework.engine import PipelineEngine
+from jpipe_runner.framework.validators import UnboundElementValidator
 from jpipe_runner.runtime import PythonRuntime
 
 
@@ -27,9 +30,7 @@ class TestJpipeLinkDecorator(unittest.TestCase):
         def my_func():
             return True
 
-        self.assertEqual(
-            my_func.__jpipe_link_ids__, ["rigor:r18:e", "rigor:r17:e_metric"]
-        )
+        self.assertEqual(my_func.__jpipe_link_ids__, ["rigor:r18:e", "rigor:r17:e_metric"])
 
     def test_returns_original_function_unchanged(self):
         def my_func():
@@ -43,6 +44,7 @@ class TestJpipeLinkDecorator(unittest.TestCase):
         ctx_backup = ctx._vars.copy()
         ctx._vars.clear()
         try:
+
             @jpipe(consume=[], produce=[])
             @jpipe_link("E1")
             def my_func():
@@ -56,6 +58,7 @@ class TestJpipeLinkDecorator(unittest.TestCase):
         ctx_backup = ctx._vars.copy()
         ctx._vars.clear()
         try:
+
             @jpipe_link("E1")
             @jpipe(consume=[], produce=[])
             def my_func():
@@ -71,15 +74,14 @@ class TestJpipeLinkDecorator(unittest.TestCase):
         ctx_backup = ctx._vars.copy()
         ctx._vars.clear()
         try:
+
             @jpipe_link("rigor:r17:e_metric")
             @jpipe_link("rigor:r18:e")
             @jpipe(consume=[], produce=[])
             def my_func():
                 return True
 
-            self.assertEqual(
-                my_func.__jpipe_link_ids__, ["rigor:r18:e", "rigor:r17:e_metric"]
-            )
+            self.assertEqual(my_func.__jpipe_link_ids__, ["rigor:r18:e", "rigor:r17:e_metric"])
         finally:
             ctx._vars = ctx_backup
 
@@ -87,6 +89,7 @@ class TestJpipeLinkDecorator(unittest.TestCase):
         ctx_backup = ctx._vars.copy()
         ctx._vars.clear()
         try:
+
             @jpipe_link("E1")
             @jpipe(consume=[], produce=[])
             def my_function():
@@ -181,7 +184,7 @@ class TestApplyLinkRegistry(unittest.TestCase):
         path = os.path.join(tmp_path, "j.json")
         with open(path, "w") as f:
             json.dump(data, f)
-        from unittest.mock import patch
+
         with patch("jpipe_runner.framework.engine.PipelineEngine.load_config"):
             engine = PipelineEngine(None, path)
         return engine
@@ -244,7 +247,7 @@ class TestAliasResolution(unittest.TestCase):
         path = os.path.join(tmp_path, "j.json")
         with open(path, "w") as f:
             json.dump(data, f)
-        from unittest.mock import patch
+
         with patch("jpipe_runner.framework.engine.PipelineEngine.load_config"):
             return PipelineEngine(None, path)
 
@@ -263,13 +266,7 @@ class TestAliasResolution(unittest.TestCase):
             ],
             "relations": [{"source": "rigor:unified_0", "target": "C1"}],
         }
-        path = os.path.join(tmp_path, "j.json")
-        with open(path, "w") as f:
-            json.dump(data, f)
-        from unittest.mock import patch
-        with patch("jpipe_runner.framework.engine.PipelineEngine.load_config"):
-            engine = PipelineEngine(None, path)
-        return engine
+        return self._make_engine_from(tmp_path, data)
 
     def test_alias_index_built_for_id_and_aliases(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -281,21 +278,15 @@ class TestAliasResolution(unittest.TestCase):
     def test_resolve_canonical_id(self):
         with tempfile.TemporaryDirectory() as tmp:
             engine = self._make_engine(tmp)
-            self.assertEqual(
-                engine._resolve_node_id("rigor:unified_0"), "rigor:unified_0"
-            )
+            self.assertEqual(engine._resolve_node_id("rigor:unified_0"), "rigor:unified_0")
 
     def test_resolve_colon_bearing_alias(self):
         # An alias containing colons must match exactly (not be rsplit into a bogus
         # qualifier/element pair) and resolve to the canonical id.
         with tempfile.TemporaryDirectory() as tmp:
             engine = self._make_engine(tmp)
-            self.assertEqual(
-                engine._resolve_node_id("rigor:r17:e_metric"), "rigor:unified_0"
-            )
-            self.assertEqual(
-                engine._resolve_node_id("rigor:r18:e"), "rigor:unified_0"
-            )
+            self.assertEqual(engine._resolve_node_id("rigor:r17:e_metric"), "rigor:unified_0")
+            self.assertEqual(engine._resolve_node_id("rigor:r18:e"), "rigor:unified_0")
 
     def test_apply_registry_binds_via_alias(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -367,9 +358,6 @@ class TestAliasResolution(unittest.TestCase):
 
 class TestUnboundValidatorConflict(unittest.TestCase):
     def test_conflicting_binding_reported_as_error_not_raised(self):
-        from jpipe_runner.framework.context import ctx as global_ctx
-        from jpipe_runner.framework.validators import UnboundElementValidator
-
         data = {
             "name": "rigor",
             "type": "justification",
@@ -388,7 +376,7 @@ class TestUnboundValidatorConflict(unittest.TestCase):
             path = os.path.join(tmp, "j.json")
             with open(path, "w") as f:
                 json.dump(data, f)
-            from unittest.mock import patch
+
             with patch("jpipe_runner.framework.engine.PipelineEngine.load_config"):
                 engine = PipelineEngine(None, path)
             engine._link_registry = {

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -437,17 +437,21 @@ class TestEvidenceDependencyValidator(unittest.TestCase):
 
 
 class TestUnboundElementValidator(unittest.TestCase):
-    def _make_pipeline(self, graph, name="test_pipeline"):
+    def _make_pipeline(self, graph, name="test_pipeline", bound=None):
+        # Binding resolution (id / qualified / alias) lives on the engine and is
+        # covered by test_link_decorator.py. Here we drive the validator directly
+        # via the engine's resolved bound-node set.
         p = MagicMock()
         p.graph = graph
         p.justification_name = name
+        p._bound_node_ids.return_value = set(bound or ())
         return p
 
     def test_unbound_evidence_raises_error(self):
         g = nx.DiGraph()
         g.add_node("E1", type="evidence", function_name="fn", label="Evidence")
 
-        v = UnboundElementValidator(self._make_pipeline(g), MagicMock(), registry={})
+        v = UnboundElementValidator(self._make_pipeline(g), MagicMock())
         errors, _ = v.validate()
 
         self.assertEqual(len(errors), 1)
@@ -458,7 +462,7 @@ class TestUnboundElementValidator(unittest.TestCase):
         g = nx.DiGraph()
         g.add_node("S1", type="strategy", function_name="fn", label="Strategy")
 
-        v = UnboundElementValidator(self._make_pipeline(g), MagicMock(), registry={})
+        v = UnboundElementValidator(self._make_pipeline(g), MagicMock())
         errors, _ = v.validate()
 
         self.assertEqual(len(errors), 1)
@@ -468,7 +472,7 @@ class TestUnboundElementValidator(unittest.TestCase):
         g = nx.DiGraph()
         g.add_node("C1", type="conclusion", function_name="fn", label="Conclusion")
 
-        v = UnboundElementValidator(self._make_pipeline(g), MagicMock(), registry={})
+        v = UnboundElementValidator(self._make_pipeline(g), MagicMock())
         errors, _ = v.validate()
         self.assertEqual(errors, [])
 
@@ -476,28 +480,30 @@ class TestUnboundElementValidator(unittest.TestCase):
         g = nx.DiGraph()
         g.add_node("SC1", type="sub-conclusion", function_name="fn", label="Sub")
 
-        v = UnboundElementValidator(self._make_pipeline(g), MagicMock(), registry={})
+        v = UnboundElementValidator(self._make_pipeline(g), MagicMock())
         errors, _ = v.validate()
         self.assertEqual(errors, [])
 
-    def test_bound_by_plain_id_passes(self):
+    def test_bound_node_passes(self):
         g = nx.DiGraph()
         g.add_node("E1", type="evidence", function_name="fn", label="Evidence")
 
         v = UnboundElementValidator(
-            self._make_pipeline(g), MagicMock(), registry={"E1": "fn"}
+            self._make_pipeline(g, bound={"E1"}), MagicMock()
         )
         errors, _ = v.validate()
         self.assertEqual(errors, [])
 
-    def test_bound_by_qualified_id_passes(self):
+    def test_alias_bound_node_passes(self):
+        # The node's canonical id is what appears in the bound set (the engine
+        # resolves the alias); the validator must honour it.
         g = nx.DiGraph()
-        g.add_node("E1", type="evidence", function_name="fn", label="Evidence")
+        g.add_node(
+            "rigor:unified_0", type="evidence", function_name="fn", label="Metrics"
+        )
 
         v = UnboundElementValidator(
-            self._make_pipeline(g, name="my_pipeline"),
-            MagicMock(),
-            registry={"my_pipeline:E1": "fn"},
+            self._make_pipeline(g, bound={"rigor:unified_0"}), MagicMock()
         )
         errors, _ = v.validate()
         self.assertEqual(errors, [])
@@ -509,7 +515,7 @@ class TestUnboundElementValidator(unittest.TestCase):
         g.add_node("C1", type="conclusion", function_name="fn3", label="Con")
 
         v = UnboundElementValidator(
-            self._make_pipeline(g), MagicMock(), registry={"E1": "fn1"}
+            self._make_pipeline(g, bound={"E1"}), MagicMock()
         )
         errors, _ = v.validate()
 


### PR DESCRIPTION
This pull request introduces major improvements to how function bindings and aliases are handled in the pipeline engine, as well as enhancements to Python module import paths. The key changes include support for multiple aliases per node (and per function), robust alias resolution for function bindings, improved detection of unbound nodes, and the ability to specify additional Python search paths at runtime.

**Alias and Binding Improvements**

* The `@jpipe_link` decorator now supports stacking, allowing a single function to be bound to multiple node ids or aliases. All ids are recorded in a list (`__jpipe_link_ids__`) instead of a single value.
* The pipeline engine (`engine.py`) builds an alias index mapping every node id and alias to the canonical node id. This enables robust resolution of both ids and aliases (including colon-bearing ones) during function dispatch and validation. [[1]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366R62-R63) [[2]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366R207-R217) [[3]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366L411-R434)
* The `_bound_node_ids()` method centralizes detection of which nodes are bound, ensuring that all aliases and ids are unified and that conflicting bindings are detected and reported.
* The `UnboundElementValidator` now uses the alias-aware binding check, so nodes are considered bound if any alias or id is linked, and the validator logic is simplified accordingly.
* The schema for justification files now explicitly allows an `aliases` array on each element.

**Python Import Path Enhancements**

* The command-line interface (`runner.py`) now supports a `--python-path`/`-p` argument, allowing users to specify extra directories for Python imports. If not specified, the current directory is used by default. [[1]](diffhunk://#diff-ac0621dc17c3fb4cfd6c13823f9adf1b64d116f381bb865378cd7f365b2de9b9R63-R65) [[2]](diffhunk://#diff-ac0621dc17c3fb4cfd6c13823f9adf1b64d116f381bb865378cd7f365b2de9b9R124-R145)
* The `PythonRuntime` class and its dynamic import/call mechanisms now honor these additional paths, using a new `path_context` context manager to temporarily modify `sys.path` for imports and function calls. [[1]](diffhunk://#diff-3b6b7835ff6637424e292d5cc66383b34d01f42c3d66da5cba3c05287cac9b6bR31) [[2]](diffhunk://#diff-3b6b7835ff6637424e292d5cc66383b34d01f42c3d66da5cba3c05287cac9b6bR40-R44) [[3]](diffhunk://#diff-3b6b7835ff6637424e292d5cc66383b34d01f42c3d66da5cba3c05287cac9b6bR65-R66) [[4]](diffhunk://#diff-3b6b7835ff6637424e292d5cc66383b34d01f42c3d66da5cba3c05287cac9b6bR77-R82) [[5]](diffhunk://#diff-3b6b7835ff6637424e292d5cc66383b34d01f42c3d66da5cba3c05287cac9b6bR119-R120) [[6]](diffhunk://#diff-3b6b7835ff6637424e292d5cc66383b34d01f42c3d66da5cba3c05287cac9b6bR129-R150) [[7]](diffhunk://#diff-f9c6e1b6ef469ed325a9dcbe4e5e9d2c4951aa3c6537e3be7d5ddd940428cd97R140-R169)

**Other Notable Changes**

* The workflow now also runs CI on the `dev` branch.

These changes significantly improve flexibility and correctness in function binding, especially for complex justifications with multiple aliases, and make it easier to manage Python dependencies and code organization.

---

**Alias and Binding System**
- `@jpipe_link` decorator now supports multiple stacked aliases per function, recording all ids in `__jpipe_link_ids__`.
- Pipeline engine builds and uses an alias index to resolve node ids and all aliases to their canonical node id for function dispatch and validation. [[1]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366R62-R63) [[2]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366R207-R217) [[3]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366L411-R434)
- `_bound_node_ids()` method centralizes and enforces alias-aware detection of bound nodes, raising errors on conflicting bindings.
- `UnboundElementValidator` updated to use alias-aware binding logic, simplifying code and improving accuracy.
- Justification schema updated to allow an `aliases` array per element.

**Python Import Path Handling**
- CLI adds `--python-path`/`-p` for specifying extra import folders; defaults to current directory if none provided. [[1]](diffhunk://#diff-ac0621dc17c3fb4cfd6c13823f9adf1b64d116f381bb865378cd7f365b2de9b9R63-R65) [[2]](diffhunk://#diff-ac0621dc17c3fb4cfd6c13823f9adf1b64d116f381bb865378cd7f365b2de9b9R124-R145)
- `PythonRuntime` and its import/call logic now use a context manager to temporarily add these paths to `sys.path` during execution. [[1]](diffhunk://#diff-3b6b7835ff6637424e292d5cc66383b34d01f42c3d66da5cba3c05287cac9b6bR31) [[2]](diffhunk://#diff-3b6b7835ff6637424e292d5cc66383b34d01f42c3d66da5cba3c05287cac9b6bR40-R44) [[3]](diffhunk://#diff-3b6b7835ff6637424e292d5cc66383b34d01f42c3d66da5cba3c05287cac9b6bR65-R66) [[4]](diffhunk://#diff-3b6b7835ff6637424e292d5cc66383b34d01f42c3d66da5cba3c05287cac9b6bR77-R82) [[5]](diffhunk://#diff-3b6b7835ff6637424e292d5cc66383b34d01f42c3d66da5cba3c05287cac9b6bR119-R120) [[6]](diffhunk://#diff-3b6b7835ff6637424e292d5cc66383b34d01f42c3d66da5cba3c05287cac9b6bR129-R150) [[7]](diffhunk://#diff-f9c6e1b6ef469ed325a9dcbe4e5e9d2c4951aa3c6537e3be7d5ddd940428cd97R140-R169)

**CI Workflow**
- CI now also runs on the `dev` branch.