### PR TITLE
Implement suffix matching for @jpipe_link resolution

### DIFF
--- a/src/jpipe_runner/framework/decorators/link_decorator.py
+++ b/src/jpipe_runner/framework/decorators/link_decorator.py
@@ -19,8 +19,15 @@ def jpipe_link(element_id: str) -> Callable[[F], F]:
     Compatible with @jpipe, @skip, and @contribution in any stacking order, because
     all three use @wraps which propagates __dict__ attributes to their wrappers.
 
-    :param element_id: The id (or alias) of the JSON element this function implements
-        (e.g. "E1" or "rigor:r17:e_metric").
+    The id need not be the full node id or alias: a trailing colon-separated
+    *suffix* also binds, so identical logic can be reused across contexts without
+    re-annotating every fully-qualified id. ``@jpipe_link("e_metric")`` and
+    ``@jpipe_link("r17:e_metric")`` both bind ``rigor:r17:e_metric``; ``"r17"`` alone
+    does not (it is not a trailing suffix). A suffix that matches more than one node
+    is ambiguous and reported as a pipeline validation error.
+
+    :param element_id: The id, alias, or trailing segment-suffix of the JSON element
+        this function implements (e.g. "E1", "rigor:r17:e_metric", or "e_metric").
     :type element_id: str
 
     Example::

--- a/src/jpipe_runner/framework/engine.py
+++ b/src/jpipe_runner/framework/engine.py
@@ -410,19 +410,34 @@ class PipelineEngine:
         Called before validation so that all downstream lookups (skip checks, contribution
         lookups, function dispatch) use the correct function name instead of the sanitized label.
 
-        Supports three id formats (see :meth:`_resolve_node_id`):
+        Supports four id formats (see :meth:`_resolve_node_id`):
         - Plain element id:                     ``"e1"``
         - Node alias (incl. colon-bearing):     ``"rigor:r17:e_metric"``
         - Qualified id with justification name: ``"performant:e1"``
+        - Segment-suffix of an id / alias:      ``"e_metric"``, ``"r17:e_metric"``
+
+        Each successful binding is logged at INFO so the ``node ← function`` mapping is
+        a visible audit trail rather than a silent, debug-only resolution.
+
+        An ambiguous suffix (matching more than one node) makes :meth:`_resolve_node_id`
+        raise. Because this pass runs *before* validation, the raise is caught here and
+        the binding skipped — the clean, user-facing error is produced during validation
+        by :meth:`_bound_node_ids` / the UnboundElementValidator.
 
         :param registry: Mapping of link_id → attr_name produced by runtime.build_link_registry().
         :type registry: dict[str, str]
         """
         self._link_registry = registry
         for link_id, attr_name in registry.items():
-            node_id = self._resolve_node_id(link_id)
+            try:
+                node_id = self._resolve_node_id(link_id)
+            except RuntimeException as e:
+                GLOBAL_LOGGER.warning(
+                    "Skipping @jpipe_link '%s' → '%s': %s", link_id, attr_name, e
+                )
+                continue
             if node_id is not None:
-                GLOBAL_LOGGER.debug(
+                GLOBAL_LOGGER.info(
                     "Linking node '%s' to function '%s' via @jpipe_link.", node_id, attr_name
                 )
                 self.graph.nodes[node_id]["function_name"] = attr_name
@@ -435,18 +450,25 @@ class PipelineEngine:
         """
         Resolve a @jpipe_link id to a graph node id.
 
-        Resolution order:
+        Resolution order (exact tiers first, so an exact binding always wins over a
+        suffix one):
         1. Exact match against the alias index — covers both canonical node ids and
            aliases, including colon-bearing aliases (``"rigor:r17:e_metric"``). This
            is tried first so aliases never fall through to the qualified-id splitter.
         2. Plain id present as a graph node (``"e1"``).
         3. Qualified id (``"justification_name:e1"``) whose prefix matches this
            pipeline's name.
+        4. Segment-suffix match: the id's colon-separated segments form a trailing
+           suffix of a node id / alias. ``"e_metric"`` and ``"r17:e_metric"`` both
+           match ``"rigor:r17:e_metric"``; ``"r17"`` alone does not (see
+           :meth:`_suffix_match`).
 
         :param link_id: The id value passed to @jpipe_link.
         :type link_id: str
         :return: The matching graph node id, or None if not found.
         :rtype: str | None
+        :raises RuntimeException: If the id is a suffix of more than one distinct node
+            (ambiguous). Ambiguity is a user error and must never resolve silently.
         """
         if link_id in self._alias_index:
             return self._alias_index[link_id]
@@ -456,7 +478,46 @@ class PipelineEngine:
             qualifier, element_id = link_id.rsplit(":", 1)
             if qualifier == self.justification_name and element_id in self.graph.nodes:
                 return element_id
-        return None
+
+        matches = self._suffix_match(link_id)
+        if not matches:
+            return None
+        if len(matches) > 1:
+            raise RuntimeException(
+                f"Ambiguous @jpipe_link suffix '{link_id}': matches nodes "
+                f"{sorted(matches)}. Use a longer, more qualified id."
+            )
+        (node_id,) = matches
+        GLOBAL_LOGGER.debug(
+            "Resolved @jpipe_link '%s' to node '%s' via segment-suffix match.",
+            link_id,
+            node_id,
+        )
+        return node_id
+
+    def _suffix_match(self, link_id: str) -> set[str]:
+        """
+        Return the canonical node ids whose id or alias has ``link_id`` as a trailing
+        segment-suffix.
+
+        A candidate identifier matches when its colon-separated segments end with the
+        exact sequence of ``link_id``'s segments — matching happens on segment
+        boundaries, so ``"metric"`` does not match ``"e_metric"``. Equal-length
+        (i.e. exact) candidates are excluded here because the caller has already tried
+        the exact tiers.
+
+        :param link_id: The id value passed to @jpipe_link.
+        :type link_id: str
+        :return: Set of distinct canonical node ids matched by suffix.
+        :rtype: set[str]
+        """
+        ann = link_id.split(":")
+        matches: set[str] = set()
+        for key, canonical_id in self._alias_index.items():
+            segments = key.split(":")
+            if len(ann) < len(segments) and segments[-len(ann):] == ann:
+                matches.add(canonical_id)
+        return matches
 
     def _bound_node_ids(self) -> set[str]:
         """
@@ -468,7 +529,9 @@ class PipelineEngine:
 
         :raises RuntimeException: If two different registry keys (e.g. two aliases of
             the same unified node) resolve to the same node but were bound to
-            different functions — a conflicting binding.
+            different functions — a conflicting binding; or if a registry key is a
+            suffix matching more than one distinct node — an ambiguous binding
+            (propagated from :meth:`_resolve_node_id`).
         :return: Set of canonical node ids that are explicitly bound.
         :rtype: set[str]
         """

--- a/src/jpipe_runner/framework/engine.py
+++ b/src/jpipe_runner/framework/engine.py
@@ -410,11 +410,11 @@ class PipelineEngine:
         Called before validation so that all downstream lookups (skip checks, contribution
         lookups, function dispatch) use the correct function name instead of the sanitized label.
 
-        Supports four id formats (see :meth:`_resolve_node_id`):
-        - Plain element id:                     ``"e1"``
-        - Node alias (incl. colon-bearing):     ``"rigor:r17:e_metric"``
-        - Qualified id with justification name: ``"performant:e1"``
-        - Segment-suffix of an id / alias:      ``"e_metric"``, ``"r17:e_metric"``
+        Ids are resolved by a single segment-suffix rule (see :meth:`_resolve_node_id`):
+        an id binds a node when its colon-separated segments are a trailing suffix of
+        the node's id or an alias — of which an exact id (``"e1"``), an alias
+        (``"rigor:r17:e_metric"``), the pipeline-qualified form (``"performant:e1"``),
+        and a shorter suffix (``"e_metric"``) are all special cases.
 
         Each successful binding is logged at INFO so the ``node ← function`` mapping is
         a visible audit trail rather than a silent, debug-only resolution.
@@ -450,18 +450,29 @@ class PipelineEngine:
         """
         Resolve a @jpipe_link id to a graph node id.
 
-        Resolution order (exact tiers first, so an exact binding always wins over a
-        suffix one):
-        1. Exact match against the alias index — covers both canonical node ids and
-           aliases, including colon-bearing aliases (``"rigor:r17:e_metric"``). This
-           is tried first so aliases never fall through to the qualified-id splitter.
-        2. Plain id present as a graph node (``"e1"``).
-        3. Qualified id (``"justification_name:e1"``) whose prefix matches this
-           pipeline's name.
-        4. Segment-suffix match: the id's colon-separated segments form a trailing
-           suffix of a node id / alias. ``"e_metric"`` and ``"r17:e_metric"`` both
-           match ``"rigor:r17:e_metric"``; ``"r17"`` alone does not (see
-           :meth:`_suffix_match`).
+        There is really only **one** matching rule — *segment-suffix matching*: an id
+        binds a node when its colon-separated segments are a trailing suffix of one of
+        the node's identifiers (its canonical id or an alias). Matching is on segment
+        boundaries, so ``"e_metric"`` and ``"r17:e_metric"`` both match
+        ``"rigor:r17:e_metric"`` while ``"metric"`` and ``"r17"`` do not. Every id
+        "format" is a case of this single rule:
+
+        - an exact id or alias is the full-length suffix;
+        - a bare or partially-qualified id (``"e_metric"``, ``"r17:e_metric"``) is a
+          shorter suffix;
+        - the pipeline-qualified ``"justification_name:e1"`` form is the exact case
+          with this pipeline's name prepended.
+
+        Two properties keep the rule well-defined:
+
+        - **Precedence** — an exact identifier match wins over a shorter suffix match,
+          so an exactly-named node is never shadowed by an unrelated suffix collision.
+        - **Ambiguity** — a suffix matching two *different* nodes is a user error and
+          raises rather than resolving silently.
+
+        The checks below are ordered to realise those two properties: the exact
+        identities first (alias index, graph node, pipeline-qualified id), then the
+        strict-suffix fallback via :meth:`_suffix_match`.
 
         :param link_id: The id value passed to @jpipe_link.
         :type link_id: str
@@ -470,6 +481,7 @@ class PipelineEngine:
         :raises RuntimeException: If the id is a suffix of more than one distinct node
             (ambiguous). Ambiguity is a user error and must never resolve silently.
         """
+        # --- Exact identifier match (full-length suffix); wins on precedence ---
         if link_id in self._alias_index:
             return self._alias_index[link_id]
         if link_id in self.graph.nodes:
@@ -479,6 +491,7 @@ class PipelineEngine:
             if qualifier == self.justification_name and element_id in self.graph.nodes:
                 return element_id
 
+        # --- Strict-suffix fallback ---
         matches = self._suffix_match(link_id)
         if not matches:
             return None
@@ -503,8 +516,8 @@ class PipelineEngine:
         A candidate identifier matches when its colon-separated segments end with the
         exact sequence of ``link_id``'s segments — matching happens on segment
         boundaries, so ``"metric"`` does not match ``"e_metric"``. Equal-length
-        (i.e. exact) candidates are excluded here because the caller has already tried
-        the exact tiers.
+        (i.e. exact) candidates are excluded here because the caller resolves exact
+        identities first, so this method only handles the strictly-shorter suffixes.
 
         :param link_id: The id value passed to @jpipe_link.
         :type link_id: str

--- a/src/jpipe_runner/framework/validators/unbound_element.py
+++ b/src/jpipe_runner/framework/validators/unbound_element.py
@@ -26,14 +26,16 @@ class UnboundElementValidator(BaseValidator):
         try:
             bound = self.pipeline._bound_node_ids()
         except RuntimeException as e:
-            # A conflicting @jpipe_link binding (e.g. two aliases of one node bound
-            # to different functions) is a user error — report it as a validation
-            # failure so the runner exits cleanly instead of raising a traceback.
+            # An invalid @jpipe_link binding — either conflicting (two aliases of one
+            # node bound to different functions) or ambiguous (a suffix id matching
+            # more than one node) — is a user error. Report it as a validation failure
+            # so the runner exits cleanly instead of raising a traceback.
             self.errors.append(
                 "[UnboundElementValidator]\n"
-                "Pipeline validation error: conflicting @jpipe_link binding.\n"
+                "Pipeline validation error: invalid @jpipe_link binding.\n"
                 f"  • Problem: {e}\n"
-                "  • Fix: Ensure all aliases of a node are bound to the same function.\n"
+                "  • Fix: Ensure all aliases of a node bind to the same function, and\n"
+                "    use a longer, more qualified id for any ambiguous suffix.\n"
             )
             GLOBAL_LOGGER.info("UnboundElementValidator completed with 1 error(s).")
             return self.errors, self.warnings

--- a/tests/e2e/resources/suffix_alias_binding/metrics.json
+++ b/tests/e2e/resources/suffix_alias_binding/metrics.json
@@ -1,0 +1,23 @@
+{
+  "elements": [
+    {
+      "id": "rigor:unified_0",
+      "label": "The model reports its metrics",
+      "type": "evidence",
+      "aliases": ["rigor:r17:e_metric", "rigor:r18:e"]
+    },
+    {
+      "id": "C1",
+      "label": "Model is rigorous",
+      "type": "conclusion"
+    }
+  ],
+  "name": "suffix_alias_binding",
+  "relations": [
+    {
+      "source": "rigor:unified_0",
+      "target": "C1"
+    }
+  ],
+  "type": "justification"
+}

--- a/tests/e2e/resources/suffix_alias_binding/metrics.py
+++ b/tests/e2e/resources/suffix_alias_binding/metrics.py
@@ -1,0 +1,20 @@
+from jpipe_runner.framework.decorators.jpipe_decorator import jpipe
+from jpipe_runner.framework.decorators.link_decorator import jpipe_link
+
+
+# The evidence node's canonical id is "rigor:unified_0" — which does NOT contain the
+# suffix "e_metric". The suffix only appears in the alias "rigor:r17:e_metric", so the
+# function binds only if suffix resolution walks the alias index and returns the
+# canonical id. This is the combined issue #93 (aliases) + #94 (suffix) scenario.
+@jpipe_link("e_metric")
+@jpipe(consume=[], produce=["metrics_reported"])
+def report_metrics(produce) -> bool:
+    """Evidence: the model reports its metrics."""
+    produce("metrics_reported", True)
+    return True
+
+
+@jpipe(consume=["metrics_reported"])
+def model_is_rigorous(metrics_reported: bool) -> bool:
+    """Conclusion: the model is rigorous when its metrics are reported."""
+    return metrics_reported

--- a/tests/e2e/resources/suffix_binding/metrics.json
+++ b/tests/e2e/resources/suffix_binding/metrics.json
@@ -1,0 +1,22 @@
+{
+  "elements": [
+    {
+      "id": "rigor:r17:e_metric",
+      "label": "The model reports its metrics",
+      "type": "evidence"
+    },
+    {
+      "id": "C1",
+      "label": "Model is rigorous",
+      "type": "conclusion"
+    }
+  ],
+  "name": "suffix_binding",
+  "relations": [
+    {
+      "source": "rigor:r17:e_metric",
+      "target": "C1"
+    }
+  ],
+  "type": "justification"
+}

--- a/tests/e2e/resources/suffix_binding/metrics.py
+++ b/tests/e2e/resources/suffix_binding/metrics.py
@@ -1,0 +1,20 @@
+from jpipe_runner.framework.decorators.jpipe_decorator import jpipe
+from jpipe_runner.framework.decorators.link_decorator import jpipe_link
+
+
+# The evidence node has the hierarchical id "rigor:r17:e_metric" but is bound here by
+# only its trailing segment "e_metric". This exercises segment-suffix resolution: the
+# short, context-free annotation still binds the fully-qualified node, enabling reuse
+# of the same logic across contexts.
+@jpipe_link("e_metric")
+@jpipe(consume=[], produce=["metrics_reported"])
+def report_metrics(produce) -> bool:
+    """Evidence: the model reports its metrics."""
+    produce("metrics_reported", True)
+    return True
+
+
+@jpipe(consume=["metrics_reported"])
+def model_is_rigorous(metrics_reported: bool) -> bool:
+    """Conclusion: the model is rigorous when its metrics are reported."""
+    return metrics_reported

--- a/tests/e2e/test_suffix_alias_binding_e2e.py
+++ b/tests/e2e/test_suffix_alias_binding_e2e.py
@@ -1,0 +1,72 @@
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+class TestSuffixAliasBindingE2E(unittest.TestCase):
+    """
+    End-to-end test for @jpipe_link suffix matching against a node *alias*.
+
+    The evidence node's canonical id is "rigor:unified_0", which does not contain the
+    suffix "e_metric" used to bind it — the suffix only appears in the alias
+    "rigor:r17:e_metric". The pipeline runs clean only if suffix resolution walks the
+    alias index and returns the canonical node id (combined #93 + #94 behaviour).
+    """
+
+    def setUp(self):
+        self.test_dir = Path(__file__).parent / "resources" / "suffix_alias_binding"
+        self.justification_file = self.test_dir / "metrics.json"
+        self.python_file = self.test_dir / "metrics.py"
+        self.justification_name = "suffix_alias_binding"
+
+        self.assertTrue(
+            self.justification_file.exists(),
+            f"Justification file not found: {self.justification_file}",
+        )
+        self.assertTrue(
+            self.python_file.exists(), f"Python file not found: {self.python_file}"
+        )
+
+    def _run_jpipe_runner(self, additional_args=None, expected_exit_code=0):
+        cmd = [
+            sys.executable,
+            "-m",
+            "jpipe_runner.runner",
+            "--library",
+            str(self.python_file),
+            str(self.justification_file),
+        ]
+        if additional_args:
+            cmd.extend(additional_args)
+
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, cwd=self.test_dir.parent.parent.parent
+        )
+
+        if result.returncode != expected_exit_code:
+            print(f"STDOUT:\n{result.stdout}")
+            print(f"STDERR:\n{result.stderr}")
+            print(f"Expected exit code {expected_exit_code}, got {result.returncode}")
+
+        self.assertEqual(result.returncode, expected_exit_code)
+        return result
+
+    def test_suffix_of_alias_binds_canonical_node(self):
+        """A suffix of an alias binds the canonical node; the pipeline passes."""
+        result = self._run_jpipe_runner()
+        self.assertIn(self.justification_name, result.stdout.lower())
+        # The canonical node executed (PASS), proving suffix-via-alias resolution.
+        self.assertIn("rigor:unified_0", result.stdout)
+        self.assertEqual(result.returncode, 0)
+
+    def test_suffix_of_alias_validation_is_clean(self):
+        """No UnboundElementValidator error for the suffix-via-alias binding."""
+        result = self._run_jpipe_runner()
+        self.assertNotIn("unboundelementvalidator", result.stderr.lower())
+        self.assertNotIn("unbound pipeline element", result.stderr.lower())
+        self.assertEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_suffix_binding_e2e.py
+++ b/tests/e2e/test_suffix_binding_e2e.py
@@ -1,0 +1,72 @@
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+class TestSuffixBindingE2E(unittest.TestCase):
+    """
+    End-to-end tests for @jpipe_link segment-suffix binding.
+
+    The justification contains an evidence node whose canonical id is the
+    fully-qualified "rigor:r17:e_metric". The implementing function is bound by only
+    the trailing segment "e_metric" — so the pipeline runs clean only if suffix
+    resolution works.
+    """
+
+    def setUp(self):
+        self.test_dir = Path(__file__).parent / "resources" / "suffix_binding"
+        self.justification_file = self.test_dir / "metrics.json"
+        self.python_file = self.test_dir / "metrics.py"
+        self.justification_name = "suffix_binding"
+
+        self.assertTrue(
+            self.justification_file.exists(),
+            f"Justification file not found: {self.justification_file}",
+        )
+        self.assertTrue(
+            self.python_file.exists(), f"Python file not found: {self.python_file}"
+        )
+
+    def _run_jpipe_runner(self, additional_args=None, expected_exit_code=0):
+        cmd = [
+            sys.executable,
+            "-m",
+            "jpipe_runner.runner",
+            "--library",
+            str(self.python_file),
+            str(self.justification_file),
+        ]
+        if additional_args:
+            cmd.extend(additional_args)
+
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, cwd=self.test_dir.parent.parent.parent
+        )
+
+        if result.returncode != expected_exit_code:
+            print(f"STDOUT:\n{result.stdout}")
+            print(f"STDERR:\n{result.stderr}")
+            print(f"Expected exit code {expected_exit_code}, got {result.returncode}")
+
+        self.assertEqual(result.returncode, expected_exit_code)
+        return result
+
+    def test_suffix_bound_pipeline_runs_and_passes(self):
+        """The suffix-bound evidence node executes and the pipeline passes."""
+        result = self._run_jpipe_runner()
+        self.assertIn(self.justification_name, result.stdout.lower())
+        # The fully-qualified node executed (PASS), proving suffix resolution worked.
+        self.assertIn("rigor:r17:e_metric", result.stdout)
+        self.assertEqual(result.returncode, 0)
+
+    def test_suffix_bound_validation_is_clean(self):
+        """No UnboundElementValidator error for the suffix-bound evidence node."""
+        result = self._run_jpipe_runner()
+        self.assertNotIn("unboundelementvalidator", result.stderr.lower())
+        self.assertNotIn("unbound pipeline element", result.stderr.lower())
+        self.assertEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_link_decorator.py
+++ b/tests/unit/test_link_decorator.py
@@ -356,6 +356,220 @@ class TestAliasResolution(unittest.TestCase):
             self.assertEqual(engine.graph.number_of_nodes(), 0)
 
 
+class TestSuffixResolution(unittest.TestCase):
+    def _make_engine_from(self, tmp_path, data):
+        path = os.path.join(tmp_path, "j.json")
+        with open(path, "w") as f:
+            json.dump(data, f)
+
+        with patch("jpipe_runner.framework.engine.PipelineEngine.load_config"):
+            return PipelineEngine(None, path)
+
+    def _make_engine(self, tmp_path):
+        data = {
+            "name": "rigor",
+            "type": "justification",
+            "elements": [
+                {
+                    "id": "rigor:r17:e_metric",
+                    "type": "evidence",
+                    "label": "The model reports its metrics",
+                },
+                {"id": "C1", "type": "conclusion", "label": "Done"},
+            ],
+            "relations": [{"source": "rigor:r17:e_metric", "target": "C1"}],
+        }
+        return self._make_engine_from(tmp_path, data)
+
+    def test_single_segment_suffix_resolves(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            self.assertEqual(engine._resolve_node_id("e_metric"), "rigor:r17:e_metric")
+
+    def test_multi_segment_suffix_resolves(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            self.assertEqual(
+                engine._resolve_node_id("r17:e_metric"), "rigor:r17:e_metric"
+            )
+
+    def test_non_suffix_segment_does_not_resolve(self):
+        # "r17" is a middle segment, not a trailing suffix — must not bind.
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            self.assertIsNone(engine._resolve_node_id("r17"))
+
+    def test_partial_segment_does_not_resolve(self):
+        # Matching happens on segment boundaries: "metric" != "e_metric".
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            self.assertIsNone(engine._resolve_node_id("metric"))
+
+    def test_suffix_resolves_through_alias_to_canonical(self):
+        # The suffix matches an alias; resolution returns the canonical node id.
+        data = {
+            "name": "rigor",
+            "type": "justification",
+            "elements": [
+                {
+                    "id": "rigor:unified_0",
+                    "type": "evidence",
+                    "label": "Metrics",
+                    "aliases": ["rigor:r17:e_metric"],
+                },
+                {"id": "C1", "type": "conclusion", "label": "Done"},
+            ],
+            "relations": [{"source": "rigor:unified_0", "target": "C1"}],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine_from(tmp, data)
+            self.assertEqual(engine._resolve_node_id("e_metric"), "rigor:unified_0")
+
+    def test_exact_match_wins_over_suffix(self):
+        # "e_metric" is BOTH the exact id of one node and a suffix of another —
+        # the exact match must take precedence and never raise ambiguity.
+        data = {
+            "name": "rigor",
+            "type": "justification",
+            "elements": [
+                {"id": "e_metric", "type": "evidence", "label": "Short"},
+                {"id": "rigor:r17:e_metric", "type": "evidence", "label": "Long"},
+                {"id": "C1", "type": "conclusion", "label": "Done"},
+            ],
+            "relations": [
+                {"source": "e_metric", "target": "C1"},
+                {"source": "rigor:r17:e_metric", "target": "C1"},
+            ],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine_from(tmp, data)
+            self.assertEqual(engine._resolve_node_id("e_metric"), "e_metric")
+
+    def test_ambiguous_suffix_raises(self):
+        # "e" is a trailing suffix of two distinct nodes — must raise, not pick one.
+        data = {
+            "name": "rigor",
+            "type": "justification",
+            "elements": [
+                {"id": "rigor:r17:e", "type": "evidence", "label": "One"},
+                {"id": "perf:r5:e", "type": "evidence", "label": "Two"},
+                {"id": "C1", "type": "conclusion", "label": "Done"},
+            ],
+            "relations": [
+                {"source": "rigor:r17:e", "target": "C1"},
+                {"source": "perf:r5:e", "target": "C1"},
+            ],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine_from(tmp, data)
+            with self.assertRaises(RuntimeException):
+                engine._resolve_node_id("e")
+
+    def test_ambiguous_suffix_across_aliases_raises(self):
+        # The collision is between two *aliases* of two distinct canonical nodes,
+        # neither canonical id containing the suffix — so ambiguity must be detected
+        # through the alias index, not just via canonical ids.
+        data = {
+            "name": "rigor",
+            "type": "justification",
+            "elements": [
+                {
+                    "id": "rigor:unified_0",
+                    "type": "evidence",
+                    "label": "One",
+                    "aliases": ["rigor:r17:e_metric"],
+                },
+                {
+                    "id": "perf:unified_1",
+                    "type": "evidence",
+                    "label": "Two",
+                    "aliases": ["perf:r5:e_metric"],
+                },
+                {"id": "C1", "type": "conclusion", "label": "Done"},
+            ],
+            "relations": [
+                {"source": "rigor:unified_0", "target": "C1"},
+                {"source": "perf:unified_1", "target": "C1"},
+            ],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine_from(tmp, data)
+            with self.assertRaises(RuntimeException):
+                engine._resolve_node_id("e_metric")
+
+    def test_apply_registry_binds_via_suffix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            engine._apply_link_registry({"e_metric": "report_metrics"})
+            self.assertEqual(
+                engine.graph.nodes["rigor:r17:e_metric"]["function_name"],
+                "report_metrics",
+            )
+
+    def test_bound_node_ids_includes_suffix_binding(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = self._make_engine(tmp)
+            engine._apply_link_registry({"e_metric": "report_metrics"})
+            self.assertIn("rigor:r17:e_metric", engine._bound_node_ids())
+
+
+class TestSuffixAmbiguityValidation(unittest.TestCase):
+    def test_ambiguous_suffix_reported_as_error_not_raised(self):
+        data = {
+            "name": "rigor",
+            "type": "justification",
+            "elements": [
+                {"id": "rigor:r17:e", "type": "evidence", "label": "One"},
+                {"id": "perf:r5:e", "type": "evidence", "label": "Two"},
+                {"id": "C1", "type": "conclusion", "label": "Done"},
+            ],
+            "relations": [
+                {"source": "rigor:r17:e", "target": "C1"},
+                {"source": "perf:r5:e", "target": "C1"},
+            ],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "j.json")
+            with open(path, "w") as f:
+                json.dump(data, f)
+
+            with patch("jpipe_runner.framework.engine.PipelineEngine.load_config"):
+                engine = PipelineEngine(None, path)
+            engine._link_registry = {"e": "some_func"}
+
+            validator = UnboundElementValidator(engine, global_ctx)
+            errors, _ = validator.validate()
+            self.assertEqual(len(errors), 1)
+            self.assertIn("ambiguous", errors[0].lower())
+
+    def test_apply_registry_tolerates_ambiguous_suffix(self):
+        # The pre-validation binding pass must not raise on an ambiguous suffix.
+        data = {
+            "name": "rigor",
+            "type": "justification",
+            "elements": [
+                {"id": "rigor:r17:e", "type": "evidence", "label": "One"},
+                {"id": "perf:r5:e", "type": "evidence", "label": "Two"},
+                {"id": "C1", "type": "conclusion", "label": "Done"},
+            ],
+            "relations": [
+                {"source": "rigor:r17:e", "target": "C1"},
+                {"source": "perf:r5:e", "target": "C1"},
+            ],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "j.json")
+            with open(path, "w") as f:
+                json.dump(data, f)
+            with patch("jpipe_runner.framework.engine.PipelineEngine.load_config"):
+                engine = PipelineEngine(None, path)
+            # Must not raise; ambiguous suffix is skipped, leaving fallback names.
+            engine._apply_link_registry({"e": "some_func"})
+            self.assertEqual(
+                engine.graph.nodes["rigor:r17:e"]["function_name"], "one"
+            )
+
+
 class TestUnboundValidatorConflict(unittest.TestCase):
     def test_conflicting_binding_reported_as_error_not_raised(self):
         data = {


### PR DESCRIPTION
This pull request introduces and documents support for segment-suffix matching in the `@jpipe_link` decorator, allowing pipeline functions to be bound to nodes using only the trailing segments of their IDs or aliases (e.g., `"e_metric"` matches `"rigor:r17:e_metric"`). The implementation ensures ambiguity is detected and reported as a validation error, and includes thorough end-to-end tests for both direct and alias-based suffix binding.

**Enhancements to `@jpipe_link` binding logic:**

- Added segment-suffix matching: a function annotated with `@jpipe_link("e_metric")` now binds to any node whose ID or alias ends with `"e_metric"`, enabling logic reuse across contexts without full qualification. Ambiguity (multiple matches) is detected and reported as a user error. [[1]](diffhunk://#diff-03d43c7586f0ad640cb81faee881e32549c7fa5e71c0c0678aa022746137ffa8L22-R30) [[2]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366L413-R440) [[3]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366L438-R471) [[4]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366R481-R520) [[5]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366L471-R534)
- Updated documentation and error messages to clarify the new suffix matching behavior and how to resolve ambiguity or conflicting bindings. [[1]](diffhunk://#diff-03d43c7586f0ad640cb81faee881e32549c7fa5e71c0c0678aa022746137ffa8L22-R30) [[2]](diffhunk://#diff-c041fb2775a92e6cbb97139100f343fa9caca517c2bddbb324c0b86516567f37L29-R38)

**Logging and validation improvements:**

- Each successful suffix-based binding is now logged at INFO level for auditability, while ambiguous matches are logged as warnings and deferred to validation for user-facing errors. [[1]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366L413-R440) [[2]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366L438-R471) [[3]](diffhunk://#diff-c60f89735d3dd77d74906479905ee14e7c2c21c53443f3fc6ad98881d08e2366R481-R520)
- The `UnboundElementValidator` now distinguishes and reports both conflicting and ambiguous `@jpipe_link` bindings as validation failures, with updated guidance in error messages.

**End-to-end testing:**

- Added new E2E test cases and resources for both direct suffix binding (`suffix_binding`) and suffix-of-alias binding (`suffix_alias_binding`), ensuring the pipeline passes and validation is clean in both scenarios. [[1]](diffhunk://#diff-fce99fb5673a9b10bfb1233e868a7864c92a70d553054ea86fc306d6db1aa9edR1-R22) [[2]](diffhunk://#diff-6ee5bfc1d5c581dd6e7d94970004f20d88d6373e277aaa65437451e7cada6811R1-R20) [[3]](diffhunk://#diff-35a85e15d51b0fd7304ef4f97cea936462fd3285eb58171671178a1fd2bdf810R1-R72) [[4]](diffhunk://#diff-cd45027d4d8bc58dbb2f8f5531cab1205c8aa563d213692777ba5ca368402357R1-R23) [[5]](diffhunk://#diff-412a530cb4d0e46034689ab0cdd0b1157ab3b2ce80dd54f96b844720931d1d07R1-R20) [[6]](diffhunk://#diff-d104d087245204ca60f9421e77a750e0e549a07eee68cb17fa8b143d908c68e1R1-R72)

These changes make binding logic in `@jpipe_link` more flexible and robust, while ensuring user errors are clearly reported and tested.