### PR TITLE
Release v3.5.1 (PPA fix-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to **jpipe-runner** are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.1] - 2026-07-18
+
+### Packaging
+- Add the `questing` and `resolute` Ubuntu series to the PPA build matrix
+  (`script/build-deb.sh`).
+- Make the PPA upload (`script/publish-ppa.sh`) resilient: retry transient
+  Launchpad upload errors, tolerate already-uploaded distros, and continue past a
+  single failure so the Homebrew publish is not skipped.
+- Re-release to complete the PPA and Homebrew publish that failed during 3.5.0
+  (transient Launchpad `550` upload error). No functional code changes since 3.5.0.
+
+_Contributors: Sébastien Mosser._
+
 ## [3.5.0] - 2026-07-18
 
 ### ⚠️ Breaking

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jpipe-runner"
-version = "3.5.0"
+version = "3.5.1"
 description = "A Justification Runner designed for jPipe."
 authors = [
     "Jason Lyu <xjasonlyu@gmail.com>",

--- a/script/build-deb.sh
+++ b/script/build-deb.sh
@@ -6,7 +6,7 @@ DEBFULLNAME="$1"; shift
 DEBEMAIL="$1"; shift
 GPG_ID="$1"; shift
 
-DISTROS=("jammy" "noble")
+DISTROS=("jammy" "noble" "questing" "resolute")
 
 echo "=== START build-deb.sh ==="
 

--- a/script/publish-ppa.sh
+++ b/script/publish-ppa.sh
@@ -19,6 +19,17 @@ sudo apt install -y dput devscripts
 MAX_RETRIES="${MAX_RETRIES:-3}"
 RETRY_DELAY="${RETRY_DELAY:-10}"
 
+# Validate the tunables up front so a bad override fails loudly instead of
+# producing confusing `seq`/`sleep` errors mid-upload.
+if ! [[ "$MAX_RETRIES" =~ ^[0-9]+$ ]] || [ "$MAX_RETRIES" -lt 1 ]; then
+  echo "Error: MAX_RETRIES must be a positive integer (got '$MAX_RETRIES')"
+  exit 1
+fi
+if ! [[ "$RETRY_DELAY" =~ ^[0-9]+$ ]]; then
+  echo "Error: RETRY_DELAY must be a non-negative integer (got '$RETRY_DELAY')"
+  exit 1
+fi
+
 # Upload each .changes file to the PPA. A single failing distro must not abort
 # the whole batch (that would leave the remaining distros — and the downstream
 # Homebrew publish — unprocessed), so we retry transient errors, treat an
@@ -41,8 +52,13 @@ for changes in "${CHANGES_FILES[@]}"; do
       uploaded=true
       break
     fi
-    echo "Upload attempt $attempt/$MAX_RETRIES for $changes failed; retrying in ${RETRY_DELAY}s..."
-    sleep "$RETRY_DELAY"
+    # Only wait if another attempt will actually follow.
+    if [ "$attempt" -lt "$MAX_RETRIES" ]; then
+      echo "Upload attempt $attempt/$MAX_RETRIES for $changes failed; retrying in ${RETRY_DELAY}s..."
+      sleep "$RETRY_DELAY"
+    else
+      echo "Upload attempt $attempt/$MAX_RETRIES for $changes failed."
+    fi
   done
 
   if ! $uploaded; then

--- a/script/publish-ppa.sh
+++ b/script/publish-ppa.sh
@@ -13,14 +13,47 @@ fi
 sudo apt update
 sudo apt install -y dput devscripts
 
-# Upload each .changes file to PPA
+# Number of upload attempts per .changes file, to ride out transient Launchpad
+# upload errors (e.g. FTP "550 Requested action not taken: internal server
+# error"). Overridable via the environment.
+MAX_RETRIES="${MAX_RETRIES:-3}"
+RETRY_DELAY="${RETRY_DELAY:-10}"
+
+# Upload each .changes file to the PPA. A single failing distro must not abort
+# the whole batch (that would leave the remaining distros — and the downstream
+# Homebrew publish — unprocessed), so we retry transient errors, treat an
+# already-uploaded distro as done, keep going, and fail at the end only if a
+# distro genuinely could not be uploaded.
+failures=()
 for changes in "${CHANGES_FILES[@]}"; do
   echo "Uploading $changes to PPA $PPA..."
-  dput ppa:"$PPA" "$changes"
-  if [ $? -ne 0 ]; then
-    echo "Error uploading $changes to PPA"
-    exit 1
+  uploaded=false
+  for attempt in $(seq 1 "$MAX_RETRIES"); do
+    if out=$(dput ppa:"$PPA" "$changes" 2>&1); then
+      echo "$out"
+      uploaded=true
+      break
+    fi
+    echo "$out"
+    # Launchpad already has this version for this series — nothing more to do.
+    if grep -qiE "already (uploaded|registered|exists)" <<<"$out"; then
+      echo "Note: $changes appears to be already uploaded; treating as done."
+      uploaded=true
+      break
+    fi
+    echo "Upload attempt $attempt/$MAX_RETRIES for $changes failed; retrying in ${RETRY_DELAY}s..."
+    sleep "$RETRY_DELAY"
+  done
+
+  if ! $uploaded; then
+    echo "Error: could not upload $changes after $MAX_RETRIES attempts"
+    failures+=("$changes")
   fi
 done
+
+if [ ${#failures[@]} -gt 0 ]; then
+  echo "The following uploads failed: ${failures[*]}"
+  exit 1
+fi
 
 echo "All uploads completed successfully."


### PR DESCRIPTION
## Why

The **v3.5.0 release pipeline failed at `publish-ppa`** — `noble` hit a transient Launchpad FTP `550 internal server error`, and since `publish-ppa.sh` aborted on the first failure, the remaining uploads and the **Homebrew tap update (`publish-homebrew-formula`) were skipped**. PyPI, the GitHub Release, and docs for 3.5.0 all succeeded.

3.5.0 is already tagged and published to PyPI (immutable), so the pipeline can't be re-run on the same version. This **packaging-only v3.5.1** re-triggers the pipeline to complete the PPA + Homebrew publish.

## Changes

- **Add `questing` and `resolute`** to the PPA build matrix (`script/build-deb.sh`).
- **Harden `script/publish-ppa.sh`**: retry transient upload errors, tolerate already-uploaded distros, and continue past a single failing distro so one flaky series can't skip the Homebrew publish (fails at the end only on a genuine, non-transient error).
- Bump `3.5.0 → 3.5.1` and add a CHANGELOG entry.

**No functional code changes since 3.5.0.**

## Before tagging
⚠️ Confirm `questing` (25.10) and `resolute` (26.04) series are **open on the Launchpad PPA** — an unopened series is a genuine rejection that retries won't fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)