### PR TITLE
Release 3.5.3

### DIFF
--- a/.github/actions/delete-pr-comment/action.yml
+++ b/.github/actions/delete-pr-comment/action.yml
@@ -31,7 +31,7 @@ runs:
     # Delete the PR comment that was posted by the runner
     # ---------------------------------------------------------------
     - name: Delete PR comment by ID
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       env:
         COMMENT_ID: ${{ inputs.comment_id }}
       with:

--- a/.github/actions/fetch-pr-comment/action.yml
+++ b/.github/actions/fetch-pr-comment/action.yml
@@ -40,7 +40,7 @@ runs:
     # We use that ID to fetch the exact comment.
     - name: Fetch PR comment by ID
       id: fetch_comment
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       env:
         COMMENT_ID: ${{ inputs.comment_id }}
       with:

--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -17,13 +17,13 @@ runs:
   using: composite
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Cache Poetry
       id: cache-poetry
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: ~/.local
         key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-python-env
         with:
           python-version: ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       version: ${{ steps.extract.outputs.version }}
       prerelease: ${{ steps.extract.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Extract and validate tag
         id: extract
@@ -54,7 +54,7 @@ jobs:
     needs: validate-version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-python-env
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -66,14 +66,14 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-python-env
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Build distribution
         run: poetry build
       - name: Upload distribution artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions
           path: dist/
@@ -83,7 +83,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-python-env
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -94,7 +94,7 @@ jobs:
           poetry run sphinx-apidoc -o source ../../src/jpipe_runner
           poetry run sphinx-build -b html source build/html
       - name: Upload documentation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: documentation
           path: docs/python_docs/build/html/
@@ -106,14 +106,14 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Download Python distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.validate-version.outputs.tag }}
           prerelease: ${{ needs.validate-version.outputs.prerelease }}
@@ -134,7 +134,7 @@ jobs:
       id-token: write
     steps:
       - name: Download distribution artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/
@@ -153,7 +153,7 @@ jobs:
         # requires Python >= 3.11 (networkx 3.5 alone refuses to install on 3.10).
         distro: [ noble, questing, resolute ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Debian packaging tools
         # Install the declared Build-Depends explicitly (not just the base
@@ -185,7 +185,13 @@ jobs:
           DEBEMAIL: ${{ secrets.DEBEMAIL }}
         run: |
           VERSION="${{ needs.validate-version.outputs.version }}"
-          dch --newversion "${VERSION}~${{ matrix.distro }}1" \
+          # Regenerate the changelog from scratch so the shipped source package
+          # contains only this release entry. `dch --newversion` would instead
+          # prepend to the committed placeholder base entry, which then leaks into
+          # the package and onto Launchpad.
+          rm -f debian/changelog
+          dch --create --package jpipe-runner \
+              --newversion "${VERSION}~${{ matrix.distro }}1" \
               --distribution "${{ matrix.distro }}" \
               --force-distribution \
               "Release v${VERSION}."
@@ -205,12 +211,12 @@ jobs:
     if: needs.validate-version.outputs.prerelease == 'false'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-python-env
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Download Python distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/
@@ -238,7 +244,7 @@ jobs:
           export CLASS_NAME="${CLASS_NAME}AT${FORMATTED_VERSION}"
           envsubst < Formula/homebrew_formula_template.rb > "tap/Formula/jpipe-runner@${VERSION}.rb"
       - name: Upload tap artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: updated-homebrew-tap
           path: tap
@@ -250,7 +256,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download formula artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: updated-homebrew-tap
           path: tap
@@ -281,19 +287,19 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Download documentation artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: documentation
           path: docs-build/
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
         with:
           enablement: true
           token: ${{ github.token }}
       - name: Upload to GitHub Pages
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs-build/
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run jpipe-runner action
         id: run_jpipe
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run jpipe-runner action with embed_image
         id: run_jpipe
@@ -186,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run jpipe-runner action
         id: run_jpipe
@@ -258,11 +258,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python 3.12
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -17,10 +17,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to **jpipe-runner** are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.5.3] - 2026-07-18
 
 ### Fixed
 - **PPA changelog no longer ships the packaging placeholder.** The release
@@ -214,6 +214,7 @@ _Contributors: Jason Lyu, Sébastien Mosser, Nicolas Lacroix._
 
 _Contributors: Jason Lyu._
 
+[3.5.3]: https://github.com/jpipe-mcscert/jpipe-runner/compare/v3.5.2...v3.5.3
 [3.5.2]: https://github.com/jpipe-mcscert/jpipe-runner/compare/v3.5.1...v3.5.2
 [3.5.1]: https://github.com/jpipe-mcscert/jpipe-runner/compare/v3.5.0...v3.5.1
 [3.5.0]: https://github.com/jpipe-mcscert/jpipe-runner/compare/v3.4.1...v3.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to **jpipe-runner** are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **PPA changelog no longer ships the packaging placeholder.** The release
+  workflow now regenerates `debian/changelog` from scratch per Ubuntu series
+  (`dch --create`) instead of prepending to the committed `0.0.0` base entry,
+  which previously leaked into the source package and onto Launchpad.
+
+### CI
+- Bumped all GitHub Actions to their current Node 24 majors
+  (`checkout@v5`, `setup-python@v6`, `upload-artifact@v7`, `download-artifact@v8`,
+  `cache@v6`, `configure-pages@v6`, `upload-pages-artifact@v5`, `deploy-pages@v5`,
+  `github-script@v9`, `softprops/action-gh-release@v3`) to clear the Node 20
+  deprecation warnings.
+
 ## [3.5.2] - 2026-07-18
 
 ### Packaging / CI

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,9 @@
 jpipe-runner (0.0.0) UNRELEASED; urgency=medium
 
-  * Placeholder base entry. The release workflow regenerates the top entry per
-    Ubuntu series via `dch --newversion "<version>~<distro>1"` before building the
-    source package, so this version is never published as-is. It is intentionally
-    0.0.0 so that any real release version sorts above it (note the `~` in
-    `<version>~<distro>1` sorts *below* `<version>`, which is the desired PPA
-    ordering but requires this base to be lower still).
+  * Placeholder for local development only. The release workflow deletes this
+    file and regenerates a single-entry changelog per Ubuntu series with
+    `dch --create --newversion "<version>~<distro>1"`, so this placeholder is
+    never shipped. It exists only so `dpkg-buildpackage` can be run locally
+    without first creating a changelog.
 
  -- jPipe Team <mossers@mcmaster.ca>  Sat, 18 Jul 2026 00:00:00 +0000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jpipe-runner"
-version = "3.5.2"
+version = "3.5.3"
 description = "A Justification Runner designed for jPipe."
 authors = [
     "Jason Lyu <xjasonlyu@gmail.com>",


### PR DESCRIPTION
Release **3.5.3** — pipeline hardening follow-up to 3.5.2.

### Fixed
- **PPA changelog no longer ships the packaging placeholder.** The release workflow now regenerates `debian/changelog` from scratch per Ubuntu series (`dch --create`) instead of prepending to the committed `0.0.0` placeholder, which previously leaked into the source package and onto Launchpad. Verified end-to-end in a noble container.

### CI
- Bumped all GitHub Actions to their current Node 24 majors (`checkout@v5`, `setup-python@v6`, `upload-artifact@v7`, `download-artifact@v8`, `cache@v6`, `configure-pages@v6`, `upload-pages-artifact@v5`, `deploy-pages@v5`, `github-script@v9`, `action-gh-release@v3`) to clear the Node 20 deprecation warnings.

### Purpose
Primarily a full end-to-end exercise of the overhauled release pipeline (matrix PPA + decoupled publishers) introduced in 3.5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)