### PR TITLE
test(action): guard --diagram glob safety; print a copy-pasteable Run…

### DIFF
--- a/script/action/run_jpipe.sh
+++ b/script/action/run_jpipe.sh
@@ -81,7 +81,13 @@ CMD+=("--format" "${FORMAT:-svg}")
 # -----------------------------------------------------------------------------
 # STEP 4: Run the command and capture output
 # -----------------------------------------------------------------------------
-echo "Running: ${CMD[*]}"
+# Print a shell-quoted rendering of the command. "${CMD[*]}" would join the
+# elements bare, displaying e.g. `--diagram *`, which looks like an unprotected
+# glob even though the array is executed safely below. %q escapes each element so
+# the log is unambiguous (and copy-pasteable).
+printf 'Running:'
+printf ' %q' "${CMD[@]}"
+printf '\n'
 OUTPUT=$("${CMD[@]}" 2>&1)  # Capture both stdout and stderr
 RESULT=$?
 
@@ -114,7 +120,7 @@ fi
 # Example:
 #   mydiagram.svg -> mydiagram_<COMMIT_SHA>.svg
 # -----------------------------------------------------------------------------
-BASENAME=$(basename "$ORIGINAL_FILE" .${FORMAT:-svg})
+BASENAME=$(basename "$ORIGINAL_FILE" ."${FORMAT:-svg}")
 RENAMED_FILE="${OUTPUT_DIR}${BASENAME}_${COMMIT_SHA}.${FORMAT:-svg}"
 
 mv "$ORIGINAL_FILE" "$RENAMED_FILE"

--- a/tests/action/test_run_jpipe_script.py
+++ b/tests/action/test_run_jpipe_script.py
@@ -66,7 +66,7 @@ class TestRunJpipeScript(unittest.TestCase):
         self.stub.write_text(STUB)
         self.stub.chmod(self.stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
 
-    def _run(self, *, variable):
+    def _run(self, *, variable="", diagram=None):
         env = {
             **os.environ,
             "PYTHON_EXEC_PATH": str(self.stub),
@@ -78,6 +78,8 @@ class TestRunJpipeScript(unittest.TestCase):
             "COMMIT_SHA": "testsha",
             "ARGV_CAPTURE": str(self.argv_capture),
         }
+        if diagram is not None:
+            env["DIAGRAM"] = diagram
         proc = subprocess.run(
             ["bash", str(SCRIPT)],
             env=env,
@@ -120,6 +122,32 @@ class TestRunJpipeScript(unittest.TestCase):
         # ...and nothing executed the embedded `touch INJECTED`.
         self.assertFalse((self.tmp / "INJECTED").exists(), "command injection occurred")
         self.assertFalse((REPO_ROOT / "INJECTED").exists(), "command injection occurred")
+
+    def test_glob_diagram_is_not_expanded_by_the_shell(self):
+        """`--diagram *` must reach jpipe-runner as a literal asterisk.
+
+        The pattern is matched against diagram names *inside the .jd.json file*, so
+        letting the shell expand it against the working directory would silently pass
+        filenames instead. `*` is the default value of the Action's `diagram` input,
+        so this is the common path, not an edge case.
+        """
+        # The script runs with cwd=self.tmp, which already holds several entries a
+        # glob would expand to. Assert that precondition so the test cannot silently
+        # become vacuous.
+        cwd_entries = sorted(p.name for p in self.tmp.iterdir())
+        self.assertTrue(
+            cwd_entries, "cwd must contain files for the glob check to be meaningful"
+        )
+
+        proc, argv = self._run(diagram="*")
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("--diagram", argv)
+        # The value following --diagram is the literal asterisk...
+        self.assertEqual(argv[argv.index("--diagram") + 1], "*")
+        # ...and no working-directory entry leaked in via expansion.
+        for name in cwd_entries:
+            self.assertNotIn(name, argv, f"glob expanded to {name!r}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request makes several improvements to the jPipe Runner GitHub Action, focusing on documentation clarity, artifact handling, and CI compatibility. The main highlights are a complete rewrite of `docs/ACTION.md` for better usability, improved handling and documentation of the `version` input, uploading diagram artifacts unzipped for easier access, and updating CI and action dependencies for compatibility with the latest GitHub Actions runners. Additionally, several code and workflow cleanups were performed.

**Documentation and Usage Improvements:**
- `docs/ACTION.md` was completely rewritten to provide a clear, usage-focused guide, including quick start, recipes, FAQ, and a full input/output reference. The documentation now correctly points to the Action's location and clarifies permissions and outputs. [[1]](diffhunk://#diff-317eb19236cb539a0c25176c284795b449244d2b3fd8d2b2f8c148d2592b8e69L1-R270) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R43)
- The `version` input is now accurately documented as a git ref (tag, branch, or SHA), not a PyPI version, in both `action.yml` and the documentation. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L45-R45) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R43)

**Artifact Handling:**
- Diagram artifacts are now uploaded unzipped via `upload-artifact@v7`, making downloads direct images instead of `.zip` files. The workflow skips the upload if no diagram was produced, preventing step failures. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L129-R143) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R43)
- The documentation and FAQ explain the implications for downloads and the required runner version. [[1]](diffhunk://#diff-317eb19236cb539a0c25176c284795b449244d2b3fd8d2b2f8c148d2592b8e69L1-R270) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R43)

**CI and Workflow Updates:**
- Updated action dependencies to their latest versions: `setup-python@v6`, `upload-artifact@v7`, and `github-script@v9`. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L97-R97) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L178-R186) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R43)
- The Ubuntu matrix for PPA publishing and CI jobs now targets `[noble, resolute, stonking]` (the two latest LTS and the current development release), dropping `questing` and keeping `jammy` excluded due to Python version requirements. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L152-R156) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L103-R104)

**Code and Workflow Cleanups:**
- All scripts in `script/action/*.sh` are now marked executable in git, allowing the removal of redundant `chmod +x` lines from `action.yml`. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L108) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L129-R143) [[3]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L156) [[4]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L178-R186) [[5]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R43)

**Bug Fixes and Robustness:**
- The PR comment no longer embeds a broken `![](null)` image when the diagram URL cannot be resolved. The `build_comment.sh` script now checks API calls, retries lookups, and degrades gracefully to a download link with a warning if necessary.

These changes collectively improve the user experience, reliability, and maintainability of the jPipe Runner GitHub Action.