### PR TITLE
Reduce Actions log noise by grouping and quieting dependency installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recipes, FAQ, with a complete input/output reference at the end. The Action's outputs
   (`result`, `diagram_path`, `pr_comment_id`) are now documented, and the permissions
   guidance is corrected — `contents: write` is needed **only** for `embed_image: true`.
+- **Much quieter Action logs.** The dependency install no longer floods the workflow log:
+  the step is wrapped in a collapsible group, `graphviz` is skipped entirely when `dot` is
+  already on the runner, and apt/pip run quietly (~300 lines of `apt`/`dpkg` output and the
+  pip progress chatter are gone). Errors and non-zero exits are still reported, so failures
+  remain diagnosable.
 
 ### CI
 - Bumped the last Node 20-era pins, in the root `action.yml` (missed by the 3.5.3 sweep,

--- a/action.yml
+++ b/action.yml
@@ -89,8 +89,24 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        sudo apt-get update
-        sudo apt-get install -y graphviz
+        echo "::group::Install system dependencies"
+        # Only the `dot` binary is needed; most GitHub-hosted runner images already
+        # ship it, so skip apt entirely when it is present.
+        #
+        # When apt IS needed, keep it quiet: -qq silences `apt-get update`, but it does
+        # NOT silence dpkg's unpack/"Setting up" chatter during install (~287 lines for
+        # graphviz), so stdout is redirected too. stderr is deliberately left alone, so
+        # a genuine failure still prints (e.g. "E: Unable to locate package") and the
+        # non-zero exit still fails the step.
+        if command -v dot >/dev/null 2>&1; then
+          echo "graphviz already available ($(dot -V 2>&1)); skipping apt."
+        else
+          export DEBIAN_FRONTEND=noninteractive
+          sudo -E apt-get update -qq
+          sudo -E apt-get install -y -qq graphviz >/dev/null
+          echo "graphviz installed."
+        fi
+        echo "::endgroup::"
 
     - name: Set up Python
       if: ${{ !inputs.python_exec_path }}

--- a/script/action/install_jpipe_runner.sh
+++ b/script/action/install_jpipe_runner.sh
@@ -8,10 +8,16 @@ set -euo pipefail
 PYTHON_EXEC_PATH="${PYTHON_EXEC_PATH:-python}"
 VERSION="${VERSION:-main}"
 
+# Install quietly: -q/-qq suppress the routine progress chatter (Collecting…,
+# Downloading…, Building wheel…) that otherwise floods the Actions log on every run.
+# Warnings and errors are still printed, so a failed install remains diagnosable.
 if poetry env info --path &>/dev/null; then
   echo "Using Poetry"
-  poetry add "git+https://github.com/jpipe-mcscert/jpipe-runner.git@${VERSION}"
+  poetry add -q "git+https://github.com/jpipe-mcscert/jpipe-runner.git@${VERSION}"
 else
   echo "Using pip"
-  $PYTHON_EXEC_PATH -m pip install -U "git+https://github.com/jpipe-mcscert/jpipe-runner.git@${VERSION}"
+  $PYTHON_EXEC_PATH -m pip install -q -q -U \
+    --disable-pip-version-check --no-input \
+    "git+https://github.com/jpipe-mcscert/jpipe-runner.git@${VERSION}"
 fi
+echo "jpipe-runner installed (ref: ${VERSION})."


### PR DESCRIPTION
This pull request focuses on making the GitHub Action logs much quieter and easier to read by suppressing routine output from dependency installation steps, while still ensuring that errors remain visible and diagnosable. The changes also improve the documentation to reflect these logging improvements.

### Logging and Dependency Installation Improvements

* The dependency installation step in `action.yml` now checks if the `dot` binary is already available and skips the `apt` install if so, reducing unnecessary output. When installation is needed, it runs `apt-get` and `dpkg` in quiet mode and groups the logs, so only errors are shown in the workflow output.
* The `script/action/install_jpipe_runner.sh` script now installs dependencies (`poetry add` and `pip install`) in quiet mode, suppressing progress and informational messages to prevent log flooding, while still printing warnings and errors.

### Documentation Updates

* The `CHANGELOG.md` has been updated to document the quieter Action logs, explaining the improvements and how errors remain diagnosable.