### PR TITLE
Fix diagram generation and artifact upload for workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   solely from `github.event.pull_request.head.sha`, which is empty for `workflow_dispatch`,
   `push` and `schedule`, leaving a dangling underscore. It now falls back to `github.sha`,
   and the suffix is omitted entirely when no SHA is available.
+- **The runner's exit code is no longer masked when it produces no diagram.** That branch
+  hard-coded `result=1`, so a runner failing with e.g. exit `2` was reported as `1` and the
+  Action failed with the wrong code. The captured runner output is now reported on this
+  path too — previously the PR comment showed an empty log for exactly the failure you most
+  needed to diagnose.
 - Diagram collection is limited to the top level of the output directory. It defaults to
   the runner workspace, which also holds the checked-out repository, so the previous
   recursive search could pick up unrelated `.svg` files from the project.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Diagrams were silently dropped when the pattern matched more than one.** The Action
+  kept only the first file `find` happened to return, so a run using the default
+  `diagram: '*'` uploaded one arbitrary diagram (directory-order dependent) and discarded
+  the rest. All generated diagrams are now kept: a single diagram is still uploaded
+  unzipped, and multiple diagrams are uploaded together as one `jpipe-diagrams` artifact.
+  New `diagram_count` and `diagram_dir` outputs expose the full set; `diagram_path` remains
+  the primary diagram and is now chosen deterministically (first alphabetically).
+- **Artifacts were named `<diagram>_.svg` on non-pull-request runs.** `COMMIT_SHA` came
+  solely from `github.event.pull_request.head.sha`, which is empty for `workflow_dispatch`,
+  `push` and `schedule`, leaving a dangling underscore. It now falls back to `github.sha`,
+  and the suffix is omitted entirely when no SHA is available.
+- Diagram collection is limited to the top level of the output directory. It defaults to
+  the runner workspace, which also holds the checked-out repository, so the previous
+  recursive search could pick up unrelated `.svg` files from the project.
 - **`docs/ACTION.md` pointed at a repository that does not exist.** The usage example used
   `jpipe-mcscert/jpipe-runner-action@main`, which 404s; the Action lives at the root of
   `jpipe-mcscert/jpipe-runner`. Anyone copy-pasting the old example got "repository not

--- a/action.yml
+++ b/action.yml
@@ -77,8 +77,14 @@ outputs:
     description: "Exit code of the jPipe Runner execution"
     value: ${{ steps.run_jpipe.outputs.result }}
   diagram_path:
-    description: "Path to the generated diagram artifact"
+    description: "Path to the primary generated diagram (first, alphabetically) — see diagram_dir for all of them"
     value: ${{ steps.run_jpipe.outputs.diagram_path }}
+  diagram_count:
+    description: "Number of diagrams generated (a wildcard `diagram` pattern can match several)"
+    value: ${{ steps.run_jpipe.outputs.diagram_count }}
+  diagram_dir:
+    description: "Directory containing every generated diagram"
+    value: ${{ steps.run_jpipe.outputs.diagram_dir }}
   pr_comment_id:
     description: "ID of the PR comment posted"
     value: ${{ steps.post_pr_comment.outputs.comment_id }}
@@ -138,18 +144,28 @@ runs:
         DIAGRAM: ${{ inputs.diagram }}
         DRY_RUN: ${{ inputs.dry_run }}
         FORMAT: ${{ inputs.format }}
-        COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        # github.event.pull_request.head.sha only exists for pull_request events.
+        # Fall back to github.sha, which is set for every event, so non-PR runs
+        # (workflow_dispatch, push, schedule) still get a commit suffix instead of
+        # producing names like "catalogue_.svg".
+        COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       run: |
         echo "::group::Run jPipe Runner"
         ${{ github.action_path }}/script/action/run_jpipe.sh
         echo "::endgroup::"
 
+    # A wildcard `diagram` pattern can produce several diagrams, but upload-artifact
+    # only supports archive:false for a SINGLE file, and a composite action cannot
+    # loop a step. So there are two mutually-exclusive uploads: the common
+    # single-diagram case keeps the unzipped raw-file download, and the
+    # multi-diagram case ships every diagram in one archive rather than dropping
+    # all but the first (which is what used to happen).
     - name: Upload diagram as artifact
       id: upload_diagram
-      # Skip when the runner produced no diagram: run_jpipe.sh exits early without
-      # setting diagram_path, and archive:false fails hard unless the path resolves
-      # to exactly one file.
-      if: always() && steps.run_jpipe.outputs.diagram_path != ''
+      # Skipped when no diagram was produced: run_jpipe.sh exits early without
+      # setting these outputs, and archive:false fails unless the path resolves to
+      # exactly one file.
+      if: always() && steps.run_jpipe.outputs.diagram_count == '1'
       uses: actions/upload-artifact@v7
       with:
         path: ${{ steps.run_jpipe.outputs.diagram_path }}
@@ -157,6 +173,16 @@ runs:
         # `name:` is intentionally omitted — it is ignored when archive is false;
         # the artifact takes the file's own name, which already equals diagram_name.
         archive: false
+
+    - name: Upload diagrams as artifact
+      id: upload_diagrams
+      if: always() && steps.run_jpipe.outputs.diagram_count != '' && steps.run_jpipe.outputs.diagram_count != '1'
+      uses: actions/upload-artifact@v7
+      with:
+        name: jpipe-diagrams
+        # Upload the dedicated diagram folder — never OUTPUT_DIR, which is the
+        # runner workspace and holds the checked-out repository.
+        path: ${{ steps.run_jpipe.outputs.diagram_dir }}
 
     - name: Commit diagram to branch
       if: ${{ inputs.embed_image == 'true' }}
@@ -182,7 +208,8 @@ runs:
       env:
         RESULT: ${{ steps.run_jpipe.outputs.result }}
         EMBED_IMAGE: ${{ inputs.embed_image }}
-        ARTIFACT_URL: ${{ steps.upload_diagram.outputs.artifact-url }}
+        # Exactly one of the two upload steps runs; take whichever produced a URL.
+        ARTIFACT_URL: ${{ steps.upload_diagram.outputs.artifact-url || steps.upload_diagrams.outputs.artifact-url }}
         IMAGE_REPO: ${{ inputs.image_repo }}
         IMAGE_PATH: ${{ inputs.image_path }}
         IMAGE_BRANCH: ${{ inputs.image_branch }}

--- a/docs/ACTION.md
+++ b/docs/ACTION.md
@@ -186,9 +186,21 @@ link and a warning instead of embedding a broken image.
 
 ### What is the artifact, and what format is it in?
 
-One file — the rendered diagram, named `<diagram>_<commit-sha>.<format>` so runs don't
-overwrite each other. It is uploaded **unzipped**, so downloading it from the workflow run
-gives you the image directly rather than a `.zip` to extract.
+It depends on how many diagrams your `diagram` pattern matches — and the default is `*`,
+which matches them all:
+
+- **One diagram** → uploaded **unzipped**, named `<diagram>_<commit-sha>.<format>`, so
+  downloading it gives you the image directly rather than a `.zip`.
+- **Several diagrams** → all of them are uploaded together in a single `jpipe-diagrams`
+  archive. (Unzipped upload only supports one file, and an Action can't loop a step, so a
+  multi-diagram run necessarily produces one archive.)
+
+Either way **nothing is dropped**. Use the `diagram_count` and `diagram_dir` outputs if you
+need to handle the set yourself; `diagram_path` points at the primary (first alphabetically)
+diagram, which is also the one embedded in the PR comment.
+
+Names carry the commit SHA so runs don't overwrite each other. On events without a pull
+request (e.g. `workflow_dispatch`), the suffix is simply omitted.
 
 > Requires an Actions runner ≥ 2.327.1 (Node 24). GitHub-hosted runners are fine; update
 > self-hosted runners if you use them.
@@ -260,7 +272,9 @@ step simply skips itself when there's no PR context.
 | Output | Description |
 |---|---|
 | `result` | Exit code of the jPipe Runner execution (`0` = success) |
-| `diagram_path` | Path to the generated diagram file |
+| `diagram_path` | Path to the **primary** diagram (first alphabetically) |
+| `diagram_count` | How many diagrams were generated |
+| `diagram_dir` | Directory containing **every** generated diagram |
 | `pr_comment_id` | ID of the posted PR comment (empty outside a PR) |
 
 ### Version pinning

--- a/script/action/run_jpipe.sh
+++ b/script/action/run_jpipe.sh
@@ -118,7 +118,24 @@ done < <(find "$OUTPUT_DIR" -maxdepth 1 -name "*.${FORMAT:-svg}" -type f | sort)
 
 if [[ ${#GENERATED[@]} -eq 0 ]]; then
   echo "No diagram file found in $OUTPUT_DIR"
-  echo "result=1" >> "$GITHUB_OUTPUT"
+  # Preserve the runner's own exit code. Hard-coding result=1 here masked the real
+  # failure reason (e.g. an exit code of 2) and made the final "Fail if jPipe
+  # Runner failed" step exit with the wrong code. Only synthesise a failure when
+  # the runner itself reported success but produced nothing.
+  if [[ "$RESULT" -eq 0 ]]; then
+    echo "::warning::jPipe Runner exited 0 but produced no ${FORMAT:-svg} diagram in $OUTPUT_DIR"
+    RESULT=1
+  fi
+  # Emit the captured output too: this is exactly the path where the user most
+  # needs the diagnostic, and without it the PR comment showed an empty log.
+  {
+    echo "result=$RESULT"
+    echo "runner_output<<EOF"
+    echo "$OUTPUT"
+    echo "EOF"
+  } >> "$GITHUB_OUTPUT"
+  echo "Runner output:"
+  echo "$OUTPUT"
   exit 0
 fi
 
@@ -155,7 +172,9 @@ RENAMED=()
 for original in "${GENERATED[@]}"; do
   base=$(basename "$original" ."${FORMAT:-svg}")
   target="${DIAGRAM_DIR}/${base}${SUFFIX}.${FORMAT:-svg}"
-  mv "$original" "$target"
+  # `--` so a diagram whose name begins with "-" is never parsed as an
+  # option. Quoting alone does not prevent that.
+  mv -- "$original" "$target"
   RENAMED+=("$target")
 done
 
@@ -193,7 +212,7 @@ echo "EOF" >> "$GITHUB_OUTPUT"
 # STEP 8: Logging for debugging
 # -----------------------------------------------------------------------------
 echo "Diagram(s) saved to: $DIAGRAM_DIR"
-ls -l "${RENAMED[@]}"
+ls -l -- "${RENAMED[@]}"
 echo "diagram_count: $DIAGRAM_COUNT"
 echo "diagram_path: $PRIMARY_FILE"
 echo "diagram_name: $(basename "$PRIMARY_FILE")"

--- a/script/action/run_jpipe.sh
+++ b/script/action/run_jpipe.sh
@@ -94,49 +94,96 @@ RESULT=$?
 echo "Command exited with code $RESULT"
 
 # -----------------------------------------------------------------------------
-# STEP 5: Locate generated diagram
+# STEP 5: Locate the generated diagrams
 #
 # Why:
-#   jPipe Runner saves the diagram into OUTPUT_DIR with a name that may vary.
+#   --diagram takes a wildcard (default "*"), so the runner may emit SEVERAL
+#   diagrams. Previously only `head -n1` was kept and the rest were silently
+#   discarded -- and which one survived depended on directory order.
 #
 # How:
-#   - Find the first file matching "*.<format>" in the directory.
+#   - Search only the TOP LEVEL of OUTPUT_DIR. It defaults to the runner
+#     workspace, which also contains the checked-out repository; a recursive
+#     search would happily pick up unrelated *.svg files from the project.
+#   - Sort the matches so the "primary" diagram is deterministic.
 #   - If none found, set result=1 and exit gracefully.
+#
+# (`while read` rather than `mapfile`: macOS ships bash 3.2, where mapfile does
+# not exist, and this script is exercised by the local test-suite.)
 # -----------------------------------------------------------------------------
-ORIGINAL_FILE=$(find "$OUTPUT_DIR" -name "*.${FORMAT:-svg}" -type f | head -n1 || true)
-if [[ -z "$ORIGINAL_FILE" ]]; then
+GENERATED=()
+while IFS= read -r found; do
+  [[ -n "$found" ]] && GENERATED+=("$found")
+done < <(find "$OUTPUT_DIR" -maxdepth 1 -name "*.${FORMAT:-svg}" -type f | sort)
+
+if [[ ${#GENERATED[@]} -eq 0 ]]; then
   echo "No diagram file found in $OUTPUT_DIR"
   echo "result=1" >> "$GITHUB_OUTPUT"
   exit 0
 fi
 
 # -----------------------------------------------------------------------------
-# STEP 6: Rename diagram file to include commit SHA
+# STEP 6: Rename with the commit SHA and gather into a dedicated folder
 #
-# Why:
-#   - This prevents overwriting in artifact storage.
+# Why the SHA:
+#   - Prevents overwriting in artifact storage.
 #   - Allows traceability back to the commit that generated the diagram.
 #
+# COMMIT_SHA can legitimately be EMPTY (e.g. a workflow_dispatch run, where
+# github.event.pull_request.head.sha does not exist). In that case the suffix is
+# omitted entirely instead of leaving a dangling underscore, which used to yield
+# nonsense names like "catalogue_.svg".
+#
+# Why a dedicated folder:
+#   The multi-diagram upload targets this directory. OUTPUT_DIR itself is the
+#   runner workspace and must NEVER be uploaded wholesale.
+#
 # Example:
-#   mydiagram.svg -> mydiagram_<COMMIT_SHA>.svg
+#   mydiagram.svg -> <OUTPUT_DIR>/jpipe-diagrams/mydiagram_<COMMIT_SHA>.svg
 # -----------------------------------------------------------------------------
-BASENAME=$(basename "$ORIGINAL_FILE" ."${FORMAT:-svg}")
-RENAMED_FILE="${OUTPUT_DIR}${BASENAME}_${COMMIT_SHA}.${FORMAT:-svg}"
+SUFFIX=""
+if [[ -n "${COMMIT_SHA:-}" ]]; then
+  SUFFIX="_${COMMIT_SHA}"
+else
+  echo "::warning::COMMIT_SHA is empty; diagram names will not carry a commit suffix."
+fi
 
-mv "$ORIGINAL_FILE" "$RENAMED_FILE"
+DIAGRAM_DIR="${OUTPUT_DIR%/}/jpipe-diagrams"
+mkdir -p "$DIAGRAM_DIR"
+
+RENAMED=()
+for original in "${GENERATED[@]}"; do
+  base=$(basename "$original" ."${FORMAT:-svg}")
+  target="${DIAGRAM_DIR}/${base}${SUFFIX}.${FORMAT:-svg}"
+  mv "$original" "$target"
+  RENAMED+=("$target")
+done
+
+DIAGRAM_COUNT=${#RENAMED[@]}
+PRIMARY_FILE="${RENAMED[0]}"
+
+if [[ "$DIAGRAM_COUNT" -gt 1 ]]; then
+  echo "Generated ${DIAGRAM_COUNT} diagrams (all are uploaded):"
+  for f in "${RENAMED[@]}"; do echo "  - $(basename "$f")"; done
+  echo "Primary diagram (used for the PR comment/embed): $(basename "$PRIMARY_FILE")"
+fi
 
 # -----------------------------------------------------------------------------
 # STEP 7: Output results to GitHub Actions variables
 #
 # These outputs can be used by subsequent steps in the workflow:
 #   - result          : Exit code of jPipe Runner
-#   - diagram_path    : Full path to renamed diagram
-#   - diagram_name    : File name of renamed diagram
+#   - diagram_path    : Full path to the PRIMARY renamed diagram
+#   - diagram_name    : File name of the primary diagram
+#   - diagram_count   : How many diagrams were generated
+#   - diagram_dir     : Folder holding every generated diagram
 #   - runner_output   : Full console output from jPipe Runner
 # -----------------------------------------------------------------------------
 echo "result=$RESULT" >> "$GITHUB_OUTPUT"
-echo "diagram_path=$RENAMED_FILE" >> "$GITHUB_OUTPUT"
-echo "diagram_name=$(basename "$RENAMED_FILE")" >> "$GITHUB_OUTPUT"
+echo "diagram_path=$PRIMARY_FILE" >> "$GITHUB_OUTPUT"
+echo "diagram_name=$(basename "$PRIMARY_FILE")" >> "$GITHUB_OUTPUT"
+echo "diagram_count=$DIAGRAM_COUNT" >> "$GITHUB_OUTPUT"
+echo "diagram_dir=$DIAGRAM_DIR" >> "$GITHUB_OUTPUT"
 
 echo "runner_output<<EOF" >> "$GITHUB_OUTPUT"
 echo "$OUTPUT" >> "$GITHUB_OUTPUT"
@@ -145,9 +192,10 @@ echo "EOF" >> "$GITHUB_OUTPUT"
 # -----------------------------------------------------------------------------
 # STEP 8: Logging for debugging
 # -----------------------------------------------------------------------------
-echo "Diagram saved to: $RENAMED_FILE"
-ls -l "$RENAMED_FILE"
-echo "diagram_path: $RENAMED_FILE"
-echo "diagram_name: $(basename "$RENAMED_FILE")"
+echo "Diagram(s) saved to: $DIAGRAM_DIR"
+ls -l "${RENAMED[@]}"
+echo "diagram_count: $DIAGRAM_COUNT"
+echo "diagram_path: $PRIMARY_FILE"
+echo "diagram_name: $(basename "$PRIMARY_FILE")"
 echo "Runner output:"
 echo "$OUTPUT"

--- a/tests/action/test_run_jpipe_script.py
+++ b/tests/action/test_run_jpipe_script.py
@@ -215,6 +215,41 @@ class TestRunJpipeScript(unittest.TestCase):
         self.assertNotIn("unrelated.svg", kept)
         self.assertTrue((nested / "unrelated.svg").exists(), "unrelated file was moved")
 
+    def test_runner_exit_code_survives_when_no_diagram_is_produced(self):
+        """A failing runner keeps its own exit code even if no diagram appears.
+
+        The no-diagram branch used to hard-code `result=1`, masking the real
+        failure (e.g. exit 2) and making the final "Fail if jPipe Runner failed"
+        step exit with the wrong code. The captured output must also be reported,
+        since this is precisely when the user needs the diagnostic.
+        """
+        # Stub that fails with a distinctive code and writes no diagram at all.
+        failing = self.tmp / "failingpython"
+        failing.write_text(
+            '#!/usr/bin/env bash\n: > "$ARGV_CAPTURE"\n'
+            'echo "boom: something went wrong"\nexit 2\n'
+        )
+        failing.chmod(failing.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+        env = {
+            **os.environ,
+            "PYTHON_EXEC_PATH": str(failing),
+            "JD_FILE": "my file.json",
+            "VARIABLE": "",
+            "FORMAT": "svg",
+            "OUTPUT_DIR": str(self.out_dir) + "/",
+            "GITHUB_OUTPUT": str(self.github_output),
+            "COMMIT_SHA": "testsha",
+            "ARGV_CAPTURE": str(self.argv_capture),
+        }
+        subprocess.run(
+            ["bash", str(SCRIPT)], env=env, cwd=self.tmp, capture_output=True, text=True
+        )
+
+        out = self._outputs()
+        self.assertEqual(out["result"], "2", "runner exit code was masked")
+        self.assertIn("boom: something went wrong", self.github_output.read_text())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/action/test_run_jpipe_script.py
+++ b/tests/action/test_run_jpipe_script.py
@@ -38,7 +38,9 @@ for ((i = 0; i < ${#args[@]}; i++)); do
     --format) fmt="${args[$((i + 1))]}" ;;
   esac
 done
-[[ -n "$outdir" ]] && : > "${outdir%/}/diagram.${fmt}"
+for name in ${STUB_DIAGRAMS:-diagram}; do
+  [[ -n "$outdir" ]] && : > "${outdir%/}/${name}.${fmt}"
+done
 exit 0
 """
 
@@ -66,7 +68,16 @@ class TestRunJpipeScript(unittest.TestCase):
         self.stub.write_text(STUB)
         self.stub.chmod(self.stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
 
-    def _run(self, *, variable="", diagram=None):
+    def _outputs(self):
+        """Parse the key=value pairs the script wrote to $GITHUB_OUTPUT."""
+        out = {}
+        for line in self.github_output.read_text().splitlines():
+            if "=" in line:
+                key, _, value = line.partition("=")
+                out.setdefault(key, value)
+        return out
+
+    def _run(self, *, variable="", diagram=None, diagrams=None, commit_sha="testsha"):
         env = {
             **os.environ,
             "PYTHON_EXEC_PATH": str(self.stub),
@@ -75,9 +86,12 @@ class TestRunJpipeScript(unittest.TestCase):
             "FORMAT": "svg",
             "OUTPUT_DIR": str(self.out_dir) + "/",
             "GITHUB_OUTPUT": str(self.github_output),
-            "COMMIT_SHA": "testsha",
+            "COMMIT_SHA": commit_sha,
             "ARGV_CAPTURE": str(self.argv_capture),
         }
+        if diagrams is not None:
+            # Space-separated basenames the stub should emit (without extension).
+            env["STUB_DIAGRAMS"] = " ".join(diagrams)
         if diagram is not None:
             env["DIAGRAM"] = diagram
         proc = subprocess.run(
@@ -148,6 +162,58 @@ class TestRunJpipeScript(unittest.TestCase):
         # ...and no working-directory entry leaked in via expansion.
         for name in cwd_entries:
             self.assertNotIn(name, argv, f"glob expanded to {name!r}")
+
+    def test_every_generated_diagram_is_kept(self):
+        """A wildcard pattern can yield several diagrams; none may be dropped.
+
+        Regression guard: the script used to keep only `find ... | head -n1`, so
+        with the default `--diagram '*'` all but one diagram were silently
+        discarded -- and which one survived depended on directory order.
+        """
+        proc, _ = self._run(diagram="*", diagrams=["catalogue", "release"])
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+        out = self._outputs()
+        self.assertEqual(out["diagram_count"], "2")
+
+        kept = sorted(p.name for p in Path(out["diagram_dir"]).iterdir())
+        self.assertEqual(kept, ["catalogue_testsha.svg", "release_testsha.svg"])
+
+        # The primary diagram is deterministic (sorted), not directory-order luck.
+        self.assertEqual(out["diagram_name"], "catalogue_testsha.svg")
+
+    def test_missing_commit_sha_does_not_leave_a_dangling_underscore(self):
+        """COMMIT_SHA is empty on non-PR events; the name must not become `x_.svg`.
+
+        `github.event.pull_request.head.sha` is empty for workflow_dispatch/push,
+        which produced artifacts literally named "catalogue_.svg".
+        """
+        proc, _ = self._run(diagrams=["catalogue"], commit_sha="")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+        out = self._outputs()
+        self.assertEqual(out["diagram_name"], "catalogue.svg")
+        self.assertNotIn("_.svg", out["diagram_name"])
+
+    def test_only_top_level_diagrams_are_collected(self):
+        """Files nested under OUTPUT_DIR must be ignored.
+
+        OUTPUT_DIR defaults to the runner workspace, which also contains the
+        checked-out repository, so a recursive search could pick up unrelated
+        images from the project itself.
+        """
+        nested = self.out_dir / "checkout" / "docs"
+        nested.mkdir(parents=True)
+        (nested / "unrelated.svg").write_text("not a generated diagram")
+
+        proc, _ = self._run(diagrams=["catalogue"])
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+        out = self._outputs()
+        self.assertEqual(out["diagram_count"], "1")
+        kept = [p.name for p in Path(out["diagram_dir"]).iterdir()]
+        self.assertNotIn("unrelated.svg", kept)
+        self.assertTrue((nested / "unrelated.svg").exists(), "unrelated file was moved")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request makes significant improvements to how diagrams are handled and uploaded in the GitHub Action, ensuring that all generated diagrams are preserved and correctly named, even when multiple diagrams are produced. It also introduces new outputs and updates documentation and tests to reflect these changes.

**Diagram handling and artifact upload:**

* All diagrams matching the pattern are now kept and uploaded: a single diagram is uploaded unzipped, while multiple diagrams are bundled together as a `jpipe-diagrams` artifact. No diagrams are silently dropped anymore. The primary diagram is chosen deterministically (first alphabetically). [[1]](diffhunk://#diff-bbea6e4248ad3bda5113208c3e8775b5e63b3306b0903f1ab09417e87fdbcbb5L97-R186) [[2]](diffhunk://#diff-bbea6e4248ad3bda5113208c3e8775b5e63b3306b0903f1ab09417e87fdbcbb5L148-R199) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11-R24) [[4]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R177-R186)
* The artifact naming logic now omits the commit SHA suffix if it's unavailable (e.g., on non-PR events), preventing dangling underscores in artifact names. [[1]](diffhunk://#diff-bbea6e4248ad3bda5113208c3e8775b5e63b3306b0903f1ab09417e87fdbcbb5L97-R186) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11-R24) [[3]](diffhunk://#diff-317eb19236cb539a0c25176c284795b449244d2b3fd8d2b2f8c148d2592b8e69L189-R203)

**Workflow and outputs:**

* New outputs `diagram_count` and `diagram_dir` are added to expose the number of diagrams and their directory; `diagram_path` now always points to the primary diagram. Workflow steps are updated to handle single vs. multiple diagram uploads accordingly. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L80-R87) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L141-R168) [[3]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L185-R212) [[4]](diffhunk://#diff-317eb19236cb539a0c25176c284795b449244d2b3fd8d2b2f8c148d2592b8e69L263-R277)

**Documentation:**

* `docs/ACTION.md` is updated to explain the new diagram handling, artifact upload behavior, and the meaning of the new outputs. [[1]](diffhunk://#diff-317eb19236cb539a0c25176c284795b449244d2b3fd8d2b2f8c148d2592b8e69L189-R203) [[2]](diffhunk://#diff-317eb19236cb539a0c25176c284795b449244d2b3fd8d2b2f8c148d2592b8e69L263-R277)

**Testing:**

* The test suite is expanded to verify that all generated diagrams are preserved, that commit SHA handling works as intended, and that only top-level diagrams are collected (not files from nested directories). [[1]](diffhunk://#diff-e1fa1245d145961f63e56ec817586f77dd293d145f64791e940775a792f30f3aL41-R43) [[2]](diffhunk://#diff-e1fa1245d145961f63e56ec817586f77dd293d145f64791e940775a792f30f3aL69-R80) [[3]](diffhunk://#diff-e1fa1245d145961f63e56ec817586f77dd293d145f64791e940775a792f30f3aL78-R94) [[4]](diffhunk://#diff-e1fa1245d145961f63e56ec817586f77dd293d145f64791e940775a792f30f3aR166-R217)

These changes ensure robust handling of diagram artifacts, better traceability, and improved user experience for workflows generating multiple diagrams.